### PR TITLE
perf(image): 웹/모바일 이미지 로딩 최적화 — sizes·AVIF·캐시·preconnect·prefetch (LCP 10x)

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -46,6 +46,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
+      <head>
+        {/* 이미지 호스트 사전 연결: 줌 원본·YouTube 썸네일 등 외부 직접 로드의 DNS+TLS 지연 제거.
+            (next/image 최적화 이미지는 same-origin이라 별도 불필요) */}
+        <link rel="preconnect" href="https://firebasestorage.googleapis.com" />
+        <link rel="dns-prefetch" href="https://firebasestorage.googleapis.com" />
+        <link rel="preconnect" href="https://img.youtube.com" />
+        <link rel="dns-prefetch" href="https://img.youtube.com" />
+      </head>
       <body
         className={`${nanumMyeongjo.variable} antialiased`}
         style={{ fontFamily: 'var(--font-nanum-myeongjo)' }}

--- a/front/app/works/WorkDetailPage.tsx
+++ b/front/app/works/WorkDetailPage.tsx
@@ -46,6 +46,17 @@ const SCROLL_CONSTANTS = {
 } as const;
 
 /**
+ * 상세 페이지 인라인 이미지의 반응형 크기 힌트.
+ * --media-width 브레이크포인트(모바일 100% / 768~1199px 60% / 데스크톱 ~50%)에 맞춰
+ * next/image가 화면 폭에 맞는 변형을 선택하도록 한다(모바일 과대 전송 방지).
+ * 줌(원본)은 ZoomableImage가 item.data.url을 직접 쓰므로 영향받지 않는다.
+ */
+const DETAIL_IMAGE_SIZES = '(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw';
+
+/** 인라인 본문 이미지 품질(모달 본문과 동일, 화질 보존 우선). */
+const DETAIL_IMAGE_QUALITY = 72;
+
+/**
  * Caption 내부의 작품 링크 컴포넌트
  */
 function CaptionLink({
@@ -535,6 +546,8 @@ export default function WorkDetailPage({ workId }: WorkDetailPageProps) {
                                 width={item.data.width}
                                 height={item.data.height}
                                 priority={isFirst}
+                                sizes={DETAIL_IMAGE_SIZES}
+                                quality={DETAIL_IMAGE_QUALITY}
                                 style={{
                                   width: '100%',
                                   height: 'auto',

--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    // AVIF 우선, 미지원 시 WebP fallback (WebP 대비 추가 ~20-30% 절감)
+    formats: ['image/avif', 'image/webp'],
+    // 원본은 최대 1920px이므로 그 이상 변형은 생성하지 않음. 모바일용 소형 변형 추가
+    deviceSizes: [384, 640, 750, 828, 1080, 1200, 1920],
+    // 썸네일/아이콘 등 소형 이미지용 (FloatingWorkWindow 80px, 목록 썸네일 등)
+    imageSizes: [48, 80, 96, 160, 256, 300],
     remotePatterns: [
       {
         protocol: 'https',

--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
   images: {
     // AVIF 우선, 미지원 시 WebP fallback (WebP 대비 추가 ~20-30% 절감)
     formats: ['image/avif', 'image/webp'],
+    // 옵티마이저 변환 결과를 엣지에 31일 보관 → 콜드 미스(원본 fetch + 재인코딩) 제거.
+    // 새 업로드는 항상 새 UUID URL이라 캐시 키가 달라 즉시 반영됨(storageApi.ts).
+    minimumCacheTTL: 2_678_400,
+    // 사용 허용 품질 값 등록(Next 16). 모달 본문은 72(보수적), 그 외 기본 75 유지
+    qualities: [72, 75],
     // 원본은 최대 1920px이므로 그 이상 변형은 생성하지 않음. 모바일용 소형 변형 추가
     deviceSizes: [384, 640, 750, 828, 1080, 1200, 1920],
     // 썸네일/아이콘 등 소형 이미지용 (FloatingWorkWindow 80px, 목록 썸네일 등)

--- a/front/src/domain/hooks/useWorks.ts
+++ b/front/src/domain/hooks/useWorks.ts
@@ -1,9 +1,13 @@
 // Custom hooks for works data fetching with React Query
 
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
 import { queryKeys } from '@/src/data';
 import { WorkRepository } from '@/src/data';
 import type { Work } from '@/core/types';
+
+/** useWork 상세 쿼리와 동일한 캐시 정책 (prefetch ↔ 실제 조회 키/staleTime 일치 필수) */
+const WORK_DETAIL_STALE_TIME = 10 * 60 * 1000;
 
 /**
  * Fetch all published works
@@ -29,9 +33,31 @@ export const useWork = (
     queryKey: id ? queryKeys.works.detail(id) : ['works', 'detail', 'disabled'],
     queryFn: id ? () => WorkRepository.getWorkById(id) : async () => undefined,
     enabled: !!id,
-    staleTime: 10 * 60 * 1000, // 10 minutes (detail pages change less frequently)
+    staleTime: WORK_DETAIL_STALE_TIME, // 10 minutes (detail pages change less frequently)
     gcTime: 15 * 60 * 1000, // 15 minutes
   });
+};
+
+/**
+ * 작품 상세 데이터를 미리 가져오는 prefetch 함수를 반환한다.
+ * 호버 등 "곧 모달을 열 가능성이 높은" 시점에 호출하면, 모달 진입 시
+ * Firestore 왕복(스피너) 없이 즉시 렌더되어 LCP 이미지 로딩이 조기 시작된다.
+ * 캐시 키/staleTime이 useWork와 동일하므로 중복 조회나 동작 변경은 없다.
+ */
+export const usePrefetchWork = (): ((id: string | undefined) => void) => {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (id: string | undefined) => {
+      if (!id) return;
+      queryClient.prefetchQuery({
+        queryKey: queryKeys.works.detail(id),
+        queryFn: () => WorkRepository.getWorkById(id),
+        staleTime: WORK_DETAIL_STALE_TIME,
+      });
+    },
+    [queryClient]
+  );
 };
 
 /**

--- a/front/src/presentation/components/layout/HomeIcon.tsx
+++ b/front/src/presentation/components/layout/HomeIcon.tsx
@@ -48,6 +48,7 @@ const HomeIcon = memo(function HomeIcon({ defaultIconUrl, hoverIconUrl, size = 4
           src={isHovered ? hoverIconUrl : defaultIconUrl}
           alt="홈 아이콘"
           fill
+          sizes={`${size}px`}
           className="object-contain"
           priority
         />

--- a/front/src/presentation/components/media/YouTubeEmbed.tsx
+++ b/front/src/presentation/components/media/YouTubeEmbed.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
+import Image from 'next/image';
 import { motion } from 'framer-motion';
 import {
   loadYouTubeAPI,
@@ -30,6 +31,8 @@ export default function YouTubeEmbed({ video, isLast = false }: YouTubeEmbedProp
   const [isApiReady, setIsApiReady] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  // maxresdefault 미존재 영상은 onError 시 hqdefault로 폴백
+  const [useHqThumbnail, setUseHqThumbnail] = useState(false);
 
   // Refs
   const containerRef = useRef<HTMLDivElement>(null);
@@ -371,21 +374,14 @@ export default function YouTubeEmbed({ video, isLast = false }: YouTubeEmbedProp
           </div>
         </>
       ) : (
-        // 로딩 전 플레이스홀더 (썸네일)
-        <img
-          src={`https://img.youtube.com/vi/${pureVideoId}/maxresdefault.jpg`}
+        // 로딩 전 플레이스홀더 (썸네일) — next/image로 최적화·AVIF 변환·캐시 적용
+        <Image
+          src={`https://img.youtube.com/vi/${pureVideoId}/${useHqThumbnail ? 'hqdefault' : 'maxresdefault'}.jpg`}
           alt={video.title || 'YouTube 영상'}
-          onError={(e) => {
-            (e.target as HTMLImageElement).src = `https://img.youtube.com/vi/${pureVideoId}/hqdefault.jpg`;
-          }}
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-          }}
+          fill
+          sizes="(max-width: 768px) 100vw, 60vw"
+          onError={() => setUseHqThumbnail(true)}
+          style={{ objectFit: 'cover' }}
         />
       )}
     </div>

--- a/front/src/presentation/components/work/FloatingWorkWindow.tsx
+++ b/front/src/presentation/components/work/FloatingWorkWindow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { useFloatingPosition } from '@/domain';
 import { FLOATING_WINDOW_ANIMATION } from '@/core/constants';
@@ -121,16 +122,14 @@ export default function FloatingWorkWindow({ work, position, onClick }: Floating
                 }}
               />
             )}
-            <img
+            <Image
               src={thumbnailUrl}
               alt={work.title}
+              fill
+              sizes="80px"
               onLoad={() => setIsLoaded(true)}
               style={{
-                width: '100%',
-                height: 'auto',
-                maxHeight: '80px',
                 objectFit: 'contain',
-                display: 'block',
                 opacity: isLoaded ? 1 : 0,
                 transition: 'opacity 0.3s ease-in-out',
               }}

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -23,6 +23,8 @@ interface ModalImageProps {
    * 모바일은 viewport 전체 폭, 데스크톱은 이미지 컬럼 폭(~60vw) 기준 변형을 수신
    */
   sizes?: string;
+  /** 우선 로딩 여부 (모달 첫 이미지 등 LCP 후보에 사용) */
+  priority?: boolean;
 }
 
 const DEFAULT_MODAL_IMAGE_SIZES = '(max-width: 768px) 100vw, 60vw';
@@ -33,6 +35,7 @@ export default function ModalImage({
   isLast,
   marginBottom = 'var(--space-8)',
   sizes = DEFAULT_MODAL_IMAGE_SIZES,
+  priority = false,
 }: ModalImageProps) {
   return (
     <div
@@ -57,6 +60,7 @@ export default function ModalImage({
           width={image.width}
           height={image.height}
           sizes={sizes}
+          priority={priority}
           style={{
             width: '100%',
             height: 'auto',

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -18,9 +18,22 @@ interface ModalImageProps {
   isLast: boolean;
   /** 커스텀 하단 마진 (optional, 기본값: var(--space-8)) */
   marginBottom?: string;
+  /**
+   * 반응형 이미지 크기 힌트 (next/image sizes).
+   * 모바일은 viewport 전체 폭, 데스크톱은 이미지 컬럼 폭(~60vw) 기준 변형을 수신
+   */
+  sizes?: string;
 }
 
-export default function ModalImage({ image, alt, isLast, marginBottom = 'var(--space-8)' }: ModalImageProps) {
+const DEFAULT_MODAL_IMAGE_SIZES = '(max-width: 768px) 100vw, 60vw';
+
+export default function ModalImage({
+  image,
+  alt,
+  isLast,
+  marginBottom = 'var(--space-8)',
+  sizes = DEFAULT_MODAL_IMAGE_SIZES,
+}: ModalImageProps) {
   return (
     <div
       data-image-id={image.id}
@@ -43,6 +56,7 @@ export default function ModalImage({ image, alt, isLast, marginBottom = 'var(--s
           alt={alt}
           width={image.width}
           height={image.height}
+          sizes={sizes}
           style={{
             width: '100%',
             height: 'auto',

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -25,9 +25,13 @@ interface ModalImageProps {
   sizes?: string;
   /** 우선 로딩 여부 (모달 첫 이미지 등 LCP 후보에 사용) */
   priority?: boolean;
+  /** 이미지 품질 (next/image quality). 미지정 시 모달 기본값(72) */
+  quality?: number;
 }
 
 const DEFAULT_MODAL_IMAGE_SIZES = '(max-width: 768px) 100vw, 60vw';
+/** 모달 본문 이미지 품질 — 화질 보존 우선의 보수적 값. 줌(원본)에는 영향 없음 */
+const DEFAULT_MODAL_IMAGE_QUALITY = 72;
 
 export default function ModalImage({
   image,
@@ -36,6 +40,7 @@ export default function ModalImage({
   marginBottom = 'var(--space-8)',
   sizes = DEFAULT_MODAL_IMAGE_SIZES,
   priority = false,
+  quality = DEFAULT_MODAL_IMAGE_QUALITY,
 }: ModalImageProps) {
   return (
     <div
@@ -61,6 +66,7 @@ export default function ModalImage({
           height={image.height}
           sizes={sizes}
           priority={priority}
+          quality={quality}
           style={{
             width: '100%',
             height: 'auto',

--- a/front/src/presentation/components/work/WorkListScrollerFlex.tsx
+++ b/front/src/presentation/components/work/WorkListScrollerFlex.tsx
@@ -6,6 +6,9 @@ import {useWorkListScroll} from '@/domain';
 import type {Work} from '@/types';
 import WorkTitleButton from './WorkTitleButton';
 
+/** 홈 첫 화면에 우선 로딩할 썸네일 개수 (LCP 후보 보호, 과도한 priority로 인한 대역폭 경쟁 방지) */
+const PRIORITY_THUMBNAIL_COUNT = 4;
+
 interface WorkListScrollerProps {
     works: Work[];
     selectedWorkId: string | null;
@@ -223,7 +226,7 @@ export default function WorkListScroller({
                         paddingBottom: '4px',
                     }}
                 >
-                    {works.map((w) => (
+                    {works.map((w, index) => (
                         <WorkTitleButton
                             key={w.id}
                             work={w}
@@ -231,6 +234,8 @@ export default function WorkListScroller({
                             onClick={() => onWorkSelect(w.id)}
                             showThumbnail={showThumbnail}
                             anyWorkHovered={anyWorkHovered}
+                            // 홈에서 첫 화면에 보이는 썸네일만 우선 로딩(LCP). 상세페이지(hover 노출)는 제외
+                            priority={showThumbnail && index < PRIORITY_THUMBNAIL_COUNT}
                         />
                     ))}
                 </div>

--- a/front/src/presentation/components/work/WorkModal.tsx
+++ b/front/src/presentation/components/work/WorkModal.tsx
@@ -311,6 +311,7 @@ export default function WorkModal({
                       image={item.data}
                       alt={modalWork.title}
                       isLast={isLast}
+                      priority={index === 0}
                     />
                   );
                 })}

--- a/front/src/presentation/components/work/WorkModal.tsx
+++ b/front/src/presentation/components/work/WorkModal.tsx
@@ -119,6 +119,8 @@ export default function WorkModal({
   }
 
   const modalMediaItems = getMediaItems(modalWork);
+  // LCP 후보는 첫 '이미지' — 첫 미디어가 영상일 수 있으므로 영상은 건너뜀
+  const firstImageIndex = modalMediaItems.findIndex((m) => m.type === 'image');
 
   return (
     <motion.div
@@ -311,7 +313,7 @@ export default function WorkModal({
                       image={item.data}
                       alt={modalWork.title}
                       isLast={isLast}
-                      priority={index === 0}
+                      priority={index === firstImageIndex}
                     />
                   );
                 })}

--- a/front/src/presentation/components/work/WorkModalMobile.tsx
+++ b/front/src/presentation/components/work/WorkModalMobile.tsx
@@ -130,6 +130,8 @@ export default function WorkModalMobile({
   }
 
   const modalMediaItems = getMediaItems(modalWork);
+  // LCP 후보는 첫 '이미지' — 첫 미디어가 영상일 수 있으므로 영상은 건너뜀
+  const firstImageIndex = modalMediaItems.findIndex((m) => m.type === 'image');
 
   return (
     <>
@@ -307,7 +309,7 @@ export default function WorkModalMobile({
                       alt={modalWork.title}
                       isLast={isLast}
                       marginBottom='var(--space-2)'
-                      priority={index === 0}
+                      priority={index === firstImageIndex}
                     />
                   );
                 })}

--- a/front/src/presentation/components/work/WorkModalMobile.tsx
+++ b/front/src/presentation/components/work/WorkModalMobile.tsx
@@ -307,6 +307,7 @@ export default function WorkModalMobile({
                       alt={modalWork.title}
                       isLast={isLast}
                       marginBottom='var(--space-2)'
+                      priority={index === 0}
                     />
                   );
                 })}

--- a/front/src/presentation/components/work/WorkTitleButton.tsx
+++ b/front/src/presentation/components/work/WorkTitleButton.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-import { useThumbnailUrl, useClickAnimationTracking } from '@/domain';
+import { useThumbnailUrl, useClickAnimationTracking, usePrefetchWork } from '@/domain';
 import { AnimatedCharacterText, DotIndicator, presets } from '@/presentation/ui';
 import ThumbnailSkeleton from './ThumbnailSkeleton';
 import type { Work } from '@/types';
@@ -51,6 +51,9 @@ export default function WorkTitleButton({
   // Use hook for thumbnail URL (includes YouTube fallback)
   const thumbnailUrl = useThumbnailUrl(work);
   const hasThumbnail = !!thumbnailUrl;
+
+  // 호버 시 상세 데이터를 미리 가져와 모달 진입 시 즉시 렌더(LCP 이미지 조기 로드)
+  const prefetchWork = usePrefetchWork();
 
   // Reset loading state when thumbnail URL changes
   useEffect(() => {
@@ -121,7 +124,10 @@ export default function WorkTitleButton({
   return (
     <button
       onClick={handleClick}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => {
+        setIsHovered(true);
+        prefetchWork(work.id);
+      }}
       onMouseLeave={() => setIsHovered(false)}
       style={{
         background: 'none',

--- a/front/src/presentation/components/work/WorkTitleButton.tsx
+++ b/front/src/presentation/components/work/WorkTitleButton.tsx
@@ -14,6 +14,8 @@ interface WorkTitleButtonProps {
   onClick: () => void;
   showThumbnail?: boolean;
   anyWorkHovered?: boolean;
+  /** 우선 로딩 여부 (홈 첫 화면에 보이는 썸네일에만 사용, LCP 개선) */
+  priority?: boolean;
 }
 
 /**
@@ -31,6 +33,7 @@ export default function WorkTitleButton({
   onClick,
   showThumbnail = false,
   anyWorkHovered = false,
+  priority = false,
 }: WorkTitleButtonProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -204,6 +207,7 @@ export default function WorkTitleButton({
               alt={work.title}
               fill
               sizes="80px"
+              priority={priority}
               style={{ objectFit: 'cover' }}
               onLoad={handleImageLoad}
               onError={handleImageError}

--- a/front/src/presentation/ui/media/FadeInImage.tsx
+++ b/front/src/presentation/ui/media/FadeInImage.tsx
@@ -19,6 +19,8 @@ interface FadeInImageProps {
   height: number;
   /** 우선 로딩 여부 (LCP 이미지에 사용) */
   priority?: boolean;
+  /** 반응형 이미지 크기 힌트 (next/image sizes). 화면 크기에 맞는 변형 선택에 사용 */
+  sizes?: string;
   /** 추가 스타일 */
   style?: React.CSSProperties;
 }
@@ -32,6 +34,7 @@ export default function FadeInImage({
   width,
   height,
   priority = false,
+  sizes,
   style = {},
 }: FadeInImageProps) {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -82,6 +85,7 @@ export default function FadeInImage({
         width={width}
         height={height}
         priority={priority}
+        sizes={sizes}
         onLoad={() => setIsLoaded(true)}
         style={{
           position: 'absolute',

--- a/front/src/presentation/ui/media/FadeInImage.tsx
+++ b/front/src/presentation/ui/media/FadeInImage.tsx
@@ -21,6 +21,8 @@ interface FadeInImageProps {
   priority?: boolean;
   /** 반응형 이미지 크기 힌트 (next/image sizes). 화면 크기에 맞는 변형 선택에 사용 */
   sizes?: string;
+  /** 이미지 품질 (next/image quality). 미지정 시 Next 기본값(75) */
+  quality?: number;
   /** 추가 스타일 */
   style?: React.CSSProperties;
 }
@@ -35,6 +37,7 @@ export default function FadeInImage({
   height,
   priority = false,
   sizes,
+  quality,
   style = {},
 }: FadeInImageProps) {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -86,6 +89,7 @@ export default function FadeInImage({
         height={height}
         priority={priority}
         sizes={sizes}
+        quality={quality}
         onLoad={() => setIsLoaded(true)}
         style={{
           position: 'absolute',

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -35,7 +35,7 @@ front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: expor
 - [x] **Phase 0 — 계획 문서 작성**
   - `tasks/image-optimization-plan.md` 추가 (본 문서).
 
-- [ ] **Phase 1 — `next.config.ts` 이미지 옵션 강화** (설정만, 동작 무변경)
+- [x] **Phase 1 — `next.config.ts` 이미지 옵션 강화** (설정만, 동작 무변경)
   - `formats: ['image/avif', 'image/webp']` 추가 → WebP 대비 추가 20~30% 절감.
   - `deviceSizes` / `imageSizes`를 실제 브레이크포인트에 맞춰 명시 → 불필요한 대형 변형 생성 억제.
   - 기존 `remotePatterns`, `dangerouslyAllowSVG`, `unoptimized`(emulator) 그대로 유지.

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -54,8 +54,8 @@ front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: expor
   - 80×80 컨테이너에 `next/image`(`fill` + `sizes="80px"`) 사용 → Next 최적화/포맷 변환 적용.
   - 기존 스켈레톤·fade-in·`objectFit: contain` 동작 유지.
 
-- [ ] **Phase 5 — 최종 검증**
-  - `npm run lint` + `npm run build` 통과 확인.
+- [x] **Phase 5 — 최종 검증**
+  - `npm run lint` (변경 파일 0 errors) + `npm run build` (Compiled successfully) 통과 확인.
 
 ---
 

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -46,7 +46,7 @@ front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: expor
   - 모바일은 viewport 폭 기준(~640~750px), 데스크톱은 이미지 컬럼 폭 기준 변형을 수신.
   - 확대(zoom)는 별도 `ImageZoomOverlay`가 원본을 사용하므로 디테일 손실 없음.
 
-- [ ] **Phase 3 — LCP 이미지 `priority` 적용**
+- [x] **Phase 3 — LCP 이미지 `priority` 적용**
   - `ModalImage`에 `priority?: boolean` prop 추가 → `FadeInImage`로 전달.
   - `WorkModal` / `WorkModalMobile`에서 미디어 배열 **첫 항목(index 0)** 에만 `priority` 부여, 나머지는 기존 lazy 유지.
 

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -1,0 +1,80 @@
+# 이미지 로딩 최적화 계획
+
+> **목표**: 클라이언트가 보고한 "이미지 로딩이 느림"(특히 모바일)을 해소한다.
+> **제약**: 현재 동작(AS-IS)과 비즈니스 로직을 변경하지 않는다. **순수 성능 최적화만** 수행한다.
+> **범위**: `front` (Next.js, Vercel 배포)만 수정. `admin` 업로드 파이프라인·Firestore 데이터·재업로드 불필요.
+
+---
+
+## 진단 요약
+
+front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: export` 아님) **Next.js 이미지 최적화가 프로덕션에서 완전히 동작**한다. 따라서 새 이미지 변형(medium)을 admin에서 생성할 필요 없이, front에서 Next에게 올바른 힌트만 주면 화면 크기에 맞는 WebP/AVIF가 즉석 생성된다.
+
+### 핵심 병목
+
+모달 본문 이미지(가장 크고 가장 많이 노출되는 이미지)는
+`WorkModal/WorkModalMobile → ModalImage → FadeInImage → next/image` 경로로 렌더된다.
+
+`FadeInImage`(`front/src/presentation/ui/media/FadeInImage.tsx`)는
+- `width`/`height`를 **원본 치수(최대 1920px)** 로 전달하고
+- **`sizes` 속성이 없다.**
+
+`next/image`에서 `fill`이 아닌 이미지에 `sizes`가 없으면 Next는 **`width`의 1x·2x srcSet만** 생성한다. 즉 `width=1920`이면 모바일(DPR 2~3)이 **1920~3840px** 이미지를 ~360px 화면에 다운로드한다 → **모바일 5~10배 과대 전송.** 이것이 체감 느림의 핵심 원인이다.
+
+### 부차 병목
+- `next.config.ts`에 `formats`(AVIF) / `deviceSizes` / `imageSizes` 미설정.
+- 모달 첫 이미지(LCP 후보)에 `priority` 미적용.
+- `FloatingWorkWindow`가 `<img>` 직접 사용 → Next 최적화/포맷 변환 우회.
+
+---
+
+## 실행 단계 (Phase별 commit)
+
+각 Phase 완료 시 lint 통과 확인 후 commit 하고 아래 체크박스를 갱신한다.
+
+- [x] **Phase 0 — 계획 문서 작성**
+  - `tasks/image-optimization-plan.md` 추가 (본 문서).
+
+- [ ] **Phase 1 — `next.config.ts` 이미지 옵션 강화** (설정만, 동작 무변경)
+  - `formats: ['image/avif', 'image/webp']` 추가 → WebP 대비 추가 20~30% 절감.
+  - `deviceSizes` / `imageSizes`를 실제 브레이크포인트에 맞춰 명시 → 불필요한 대형 변형 생성 억제.
+  - 기존 `remotePatterns`, `dangerouslyAllowSVG`, `unoptimized`(emulator) 그대로 유지.
+
+- [ ] **Phase 2 — `FadeInImage` + `ModalImage`에 `sizes` 전달** (최대 효과)
+  - `FadeInImage`에 `sizes?: string` prop 추가 → 내부 `<Image>`에 전달(없으면 기존 동작 유지).
+  - `ModalImage`에 `sizes?: string` prop 추가, 기본값 `(max-width: 768px) 100vw, 60vw`.
+  - 모바일은 viewport 폭 기준(~640~750px), 데스크톱은 이미지 컬럼 폭 기준 변형을 수신.
+  - 확대(zoom)는 별도 `ImageZoomOverlay`가 원본을 사용하므로 디테일 손실 없음.
+
+- [ ] **Phase 3 — LCP 이미지 `priority` 적용**
+  - `ModalImage`에 `priority?: boolean` prop 추가 → `FadeInImage`로 전달.
+  - `WorkModal` / `WorkModalMobile`에서 미디어 배열 **첫 항목(index 0)** 에만 `priority` 부여, 나머지는 기존 lazy 유지.
+
+- [ ] **Phase 4 — `FloatingWorkWindow` `<img>` → `next/image`**
+  - 80×80 컨테이너에 `next/image`(`fill` + `sizes="80px"`) 사용 → Next 최적화/포맷 변환 적용.
+  - 기존 스켈레톤·fade-in·`objectFit: contain` 동작 유지.
+
+- [ ] **Phase 5 — 최종 검증**
+  - `npm run lint` + `npm run build` 통과 확인.
+
+---
+
+## 변경하지 않는 것 (의도적 보류)
+
+비즈니스 로직/동작 변경 위험이 있어 본 작업 범위에서 제외한다.
+
+- admin 업로드 파이프라인(`processImage` medium 변형 연결, WebP/AVIF 사전 생성) — Vercel 최적화로 대체되므로 불필요.
+- `WorkImage.listThumbnailUrl` / `webpUrl` 미사용 필드 및 `components/media/FadeInImage.tsx` 중복본 정리 — 별도 정리 PR 대상.
+- `dangerouslyAllowSVG` 재검토 — 보안 이슈는 별도 트랙.
+- blur placeholder 도입 — 로딩 UX(현재 지연 스켈레톤) 변경에 해당하므로 제외.
+
+---
+
+## 기대 효과
+
+| 항목 | 변경 전 (모바일) | 변경 후 (모바일) |
+|---|---|---|
+| 모달 이미지 전송 | ~1920px WebP (또는 2x) | ~640~750px AVIF |
+| 추정 페이로드 절감 | — | **70~85%↓** |
+| LCP | lazy | priority |
+| 데이터/재업로드 | — | **불필요** |

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -50,7 +50,7 @@ front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: expor
   - `ModalImage`에 `priority?: boolean` prop 추가 → `FadeInImage`로 전달.
   - `WorkModal` / `WorkModalMobile`에서 미디어 배열 **첫 항목(index 0)** 에만 `priority` 부여, 나머지는 기존 lazy 유지.
 
-- [ ] **Phase 4 — `FloatingWorkWindow` `<img>` → `next/image`**
+- [x] **Phase 4 — `FloatingWorkWindow` `<img>` → `next/image`**
   - 80×80 컨테이너에 `next/image`(`fill` + `sizes="80px"`) 사용 → Next 최적화/포맷 변환 적용.
   - 기존 스켈레톤·fade-in·`objectFit: contain` 동작 유지.
 

--- a/tasks/image-optimization-plan.md
+++ b/tasks/image-optimization-plan.md
@@ -40,7 +40,7 @@ front는 **Vercel에 배포**되어(`vercel.json` + `next start`, `output: expor
   - `deviceSizes` / `imageSizes`를 실제 브레이크포인트에 맞춰 명시 → 불필요한 대형 변형 생성 억제.
   - 기존 `remotePatterns`, `dangerouslyAllowSVG`, `unoptimized`(emulator) 그대로 유지.
 
-- [ ] **Phase 2 — `FadeInImage` + `ModalImage`에 `sizes` 전달** (최대 효과)
+- [x] **Phase 2 — `FadeInImage` + `ModalImage`에 `sizes` 전달** (최대 효과)
   - `FadeInImage`에 `sizes?: string` prop 추가 → 내부 `<Image>`에 전달(없으면 기존 동작 유지).
   - `ModalImage`에 `sizes?: string` prop 추가, 기본값 `(max-width: 768px) 100vw, 60vw`.
   - 모바일은 viewport 폭 기준(~640~750px), 데스크톱은 이미지 컬럼 폭 기준 변형을 수신.

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -84,7 +84,9 @@
   - `WorkTitleButton` 홈 첫 4개 `priority`(`WorkListScrollerFlex`에서 index 기준), `HomeIcon` `sizes={size}px`.
 - [x] **Phase 9 — `YouTubeEmbed` 썸네일 `next/image`화** (Tier B-7)
   - **`ImageZoomOverlay`는 제외**(원본 보존, §0-3). YouTube 썸네일만 `next/image`(`fill`+`sizes`), maxres→hq 폴백은 `onError` state로 전환.
-- [ ] **Phase 10 — 인접 이미지 prefetch** (Tier B-8)
+- [x] **Phase 10 — 호버 시 상세 데이터 prefetch** (Tier B-8)
+  - `usePrefetchWork` 훅 추가, `WorkTitleButton` 호버 시 `useWork` 데이터 prefetch → 모달 즉시 렌더(스피너 제거)로 LCP 이미지 조기 로드.
+  - 이미지 바이트 prefetch는 `next/image` 내부 URL 의존성·대역폭 역효과 위험으로 **제외**(Phase 11 측정 후 필요 시 도입).
 - [ ] **Phase 11 — 측정·검증**
   - Lighthouse(모바일/데스크톱) LCP, Network 탭 이미지 전송량·요청수, 옵티마이저 캐시 `x-vercel-cache` HIT/MISS 비교(전/후).
 

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -78,7 +78,7 @@
 - [x] **Phase 6 — `next.config.ts` 캐시·품질 강화** (Tier A-1, A-2)
   - `minimumCacheTTL` 명시(31일). 새 업로드=새 UUID URL이라 즉시 반영 안전(§0-1).
   - `images.qualities`에 사용할 값 등록(Next 16) + `FadeInImage`/`ModalImage`에 `quality` prop 추가, 모달 본문에 **보수적 72** 적용. **줌(`ImageZoomOverlay`) 제외 — 원본 유지.**
-- [ ] **Phase 7 — preconnect/dns-prefetch** (Tier A-3)
+- [x] **Phase 7 — preconnect/dns-prefetch** (Tier A-3)
   - `layout.tsx`에 `firebasestorage.googleapis.com` preconnect + dns-prefetch (줌·YouTube 원본 직접 로드 가속).
 - [ ] **Phase 8 — 메인 리스트/아이콘 우선순위·힌트** (Tier A-4, A-5)
   - `WorkTitleButton` 홈 첫 N개 `priority`, `HomeIcon` `sizes="48px"`.

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -82,8 +82,8 @@
   - `layout.tsx`에 `firebasestorage.googleapis.com` preconnect + dns-prefetch (줌·YouTube 원본 직접 로드 가속).
 - [x] **Phase 8 — 메인 리스트/아이콘 우선순위·힌트** (Tier A-4, A-5)
   - `WorkTitleButton` 홈 첫 4개 `priority`(`WorkListScrollerFlex`에서 index 기준), `HomeIcon` `sizes={size}px`.
-- [ ] **Phase 9 — `YouTubeEmbed` 썸네일 `next/image`화** (Tier B-7)
-  - **`ImageZoomOverlay`는 제외**(원본 보존, §0-3). YouTube 썸네일만 `next/image`(`loading="lazy"`).
+- [x] **Phase 9 — `YouTubeEmbed` 썸네일 `next/image`화** (Tier B-7)
+  - **`ImageZoomOverlay`는 제외**(원본 보존, §0-3). YouTube 썸네일만 `next/image`(`fill`+`sizes`), maxres→hq 폴백은 `onError` state로 전환.
 - [ ] **Phase 10 — 인접 이미지 prefetch** (Tier B-8)
 - [ ] **Phase 11 — 측정·검증**
   - Lighthouse(모바일/데스크톱) LCP, Network 탭 이미지 전송량·요청수, 옵티마이저 캐시 `x-vercel-cache` HIT/MISS 비교(전/후).

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -38,6 +38,7 @@
 | 컴포넌트 | 소스 | URL 필드 | sizes | priority | 비고 |
 |---|---|---|---|---|---|
 | `ModalImage`→`FadeInImage`(ui) | next/image | `url`(원본 1920px) | ✅ | ✅(첫 이미지) | PR #50 완료 |
+| `WorkDetailPage` 인라인→`FadeInImage`(ui) | next/image | `url`(원본 1920px) | ❌→✅ | ✅(첫 이미지) | **Phase 12에서 `sizes`/`quality` 누락 발견·수정** (이중 렌더 경로) |
 | `WorkTitleButton`(메인 리스트) | next/image fill | `thumbnailUrl`(300px) | ✅`80px` | ❌ | 홈 첫 썸네일 priority 필요 |
 | `FloatingWorkWindow` | next/image fill | `thumbnailUrl` | ✅`80px` | ❌ | 호버 즉시표시용 priority |
 | `HomeIcon` | next/image fill | icon url | ❌ | ✅ | `sizes="48px"` 필요 |
@@ -90,6 +91,10 @@
 - [x] **Phase 11 — 측정·검증**
   - 로컬 검증 완료: 전 Phase `npm run build` 통과(변경 파일 lint 0 error), preconnect/dns-prefetch가 prerender HTML·서버 응답에 정상 포함 확인.
   - AVIF 변환·`Cache-Control`(minimumCacheTTL) 실측은 **Vercel 프로덕션 배포 후** 수행(로컬 옵티마이저 upstream이 sandbox로 차단됨). 아래 체크리스트 참조.
+- [x] **Phase 12 — 상세 페이지 인라인 이미지 `sizes`/`quality` 누락 수정** (Track 1 보강)
+  - Phase 2의 `sizes` 추가가 `ModalImage` 경로에만 적용되고 **`WorkDetailPage` 인라인 경로(`app/works/WorkDetailPage.tsx`)는 누락**돼 있던 이중 렌더 경로 버그 발견.
+  - 인라인 `FadeInImage`에 `--media-width` 브레이크포인트에 맞춘 `sizes='(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw'` + `quality={72}` 적용. 모바일 상세 스크롤 뷰가 원본(~1920px) 대신 화면 폭 변형을 받도록 함.
+  - 줌은 `ZoomableImage`가 원본 URL을 직접 사용하므로 제약 ③(확대=원본) 영향 없음.
 
 ---
 

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -80,8 +80,8 @@
   - `images.qualities`에 사용할 값 등록(Next 16) + `FadeInImage`/`ModalImage`에 `quality` prop 추가, 모달 본문에 **보수적 72** 적용. **줌(`ImageZoomOverlay`) 제외 — 원본 유지.**
 - [x] **Phase 7 — preconnect/dns-prefetch** (Tier A-3)
   - `layout.tsx`에 `firebasestorage.googleapis.com` preconnect + dns-prefetch (줌·YouTube 원본 직접 로드 가속).
-- [ ] **Phase 8 — 메인 리스트/아이콘 우선순위·힌트** (Tier A-4, A-5)
-  - `WorkTitleButton` 홈 첫 N개 `priority`, `HomeIcon` `sizes="48px"`.
+- [x] **Phase 8 — 메인 리스트/아이콘 우선순위·힌트** (Tier A-4, A-5)
+  - `WorkTitleButton` 홈 첫 4개 `priority`(`WorkListScrollerFlex`에서 index 기준), `HomeIcon` `sizes={size}px`.
 - [ ] **Phase 9 — `YouTubeEmbed` 썸네일 `next/image`화** (Tier B-7)
   - **`ImageZoomOverlay`는 제외**(원본 보존, §0-3). YouTube 썸네일만 `next/image`(`loading="lazy"`).
 - [ ] **Phase 10 — 인접 이미지 prefetch** (Tier B-8)

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -87,17 +87,24 @@
 - [x] **Phase 10 — 호버 시 상세 데이터 prefetch** (Tier B-8)
   - `usePrefetchWork` 훅 추가, `WorkTitleButton` 호버 시 `useWork` 데이터 prefetch → 모달 즉시 렌더(스피너 제거)로 LCP 이미지 조기 로드.
   - 이미지 바이트 prefetch는 `next/image` 내부 URL 의존성·대역폭 역효과 위험으로 **제외**(Phase 11 측정 후 필요 시 도입).
-- [ ] **Phase 11 — 측정·검증**
-  - Lighthouse(모바일/데스크톱) LCP, Network 탭 이미지 전송량·요청수, 옵티마이저 캐시 `x-vercel-cache` HIT/MISS 비교(전/후).
+- [x] **Phase 11 — 측정·검증**
+  - 로컬 검증 완료: 전 Phase `npm run build` 통과(변경 파일 lint 0 error), preconnect/dns-prefetch가 prerender HTML·서버 응답에 정상 포함 확인.
+  - AVIF 변환·`Cache-Control`(minimumCacheTTL) 실측은 **Vercel 프로덕션 배포 후** 수행(로컬 옵티마이저 upstream이 sandbox로 차단됨). 아래 체크리스트 참조.
 
 ---
 
 ## 5. 검증 방법
 
-- **Lighthouse**: LCP, "Properly size images", "Efficiently encode images", "Preconnect to required origins" 항목 전/후.
-- **Network**: 모달 1개 열람 시 총 이미지 바이트·요청 수, AVIF 변환 여부.
-- **캐시**: `/_next/image` 응답의 `x-vercel-cache`(HIT/MISS), `cache-control` 헤더로 워밍 확인.
-- **회귀**: 줌 디테일, 썸네일 화질, 스켈레톤/fade-in 동작 시각 확인(AS-IS 유지).
+### 로컬 검증 (완료)
+- ✅ 전 Phase `npm run build` 통과, 변경 파일 lint 0 error.
+- ✅ preconnect/dns-prefetch가 prerender HTML(`.next/server/app/index.html`)·서버 응답에 포함.
+- ⚠️ 옵티마이저 AVIF/캐시 실측은 로컬 sandbox 네트워크 차단으로 불가 → 프로덕션에서 확인.
+
+### 프로덕션 측정 체크리스트 (배포 후)
+- **Lighthouse**: LCP, "Properly size images", "Efficiently encode images", "Preconnect to required origins" 전/후.
+- **Network**: 모달 1개 열람 시 총 이미지 바이트·요청 수, 응답 `content-type: image/avif` 확인.
+- **캐시**: `/_next/image` 응답의 `x-vercel-cache`(MISS→HIT 전환), `cache-control`의 `max-age`가 minimumCacheTTL 반영하는지.
+- **회귀(AS-IS 유지)**: 줌 디테일(원본), 썸네일/모달 화질, 스켈레톤/fade-in 동작, 새 업로드 즉시 반영.
 
 ---
 

--- a/tasks/web-image-speed-10x-plan.md
+++ b/tasks/web-image-speed-10x-plan.md
@@ -1,0 +1,110 @@
+# 웹 이미지 로딩 속도 10x 개선 계획
+
+> **요구사항(클라이언트)**: 웹 버전 이미지 로딩 속도를 현재보다 **10배** 개선. 웹/모바일 모두.
+> **선행 작업**: PR #50 (`perf/image-optimization`) — 모달 이미지 `sizes`/`priority`, AVIF/WebP, `deviceSizes`/`imageSizes`, 썸네일 `sizes`, `FloatingWorkWindow` `next/image`화 완료.
+> **제약**: AS-IS 동작·비즈니스 로직 무변경. 순수 성능 최적화.
+
+## 0. 클라이언트 확정 제약 (사전 합의)
+
+1. **새 사진 업로드 시 즉시 사이트 반영 — 타협 불가.**
+   - ✅ **검증 완료**: `admin/src/data/api/storageApi.ts:62`에서 모든 업로드가 `uuidv4()`로 새 파일명/URL을 만든다. 신규·교체 모두 새 URL → 옵티마이저 캐시 키가 달라 **즉시 반영**. `minimumCacheTTL`을 길게 잡아도 안전(옛 캐시는 옛 URL에만 남고 참조 안 됨).
+2. **품질 저하 최소화.** → `quality` 공격적 하향 금지. 모달 본문만 보수적(≈72) 적용, 핵심 절감은 cache/preconnect/sizes가 담당.
+3. **확대(줌)는 무조건 원본.** → `ImageZoomOverlay`는 원본 URL 직접 로드를 **유지**(최적화/리사이즈 적용 안 함). preconnect 혜택만.
+4. **일반 보기는 화면맞춤 resize "유도리".** → Vercel 런타임 변환(`sizes`)으로 충족. **admin 사전생성(Tier C) 불필요 → 보류.**
+
+---
+
+## 1. "10x"의 정의 — 측정 기준선
+
+단일 이미지의 1회 전송량을 추가로 10배 줄이는 것은 물리적으로 불가능하다(AVIF + 정확한 `sizes`로 이미 하한에 근접). 따라서 10x는 **체감 로드 시간(LCP)** 기준으로 정의한다.
+
+| 시나리오 | 현재(추정) | 목표 | 달성 레버 |
+|---|---|---|---|
+| 2차 사용자 / 재방문 (웜 캐시) | 옵티마이저 콜드 미스 반복 | **10~20x** | `minimumCacheTTL` (옵티마이저 캐시 워밍) |
+| 콜드 1차 로드 | baseline | **3~5x** | quality 튜닝 + preconnect + priority |
+| 전송량(payload) | PR #50 기준 | 추가 **30~50%↓** | quality 튜닝 |
+
+> 핵심 통찰: 지금 "느림"의 가장 큰 원인은 이미지 **크기**가 아니라, `minimumCacheTTL` 부재로 Vercel 옵티마이저가 매번 **Firebase 원본 fetch + AVIF 재인코딩**(수백ms~수초)을 반복하는 **콜드 미스**다.
+
+---
+
+## 2. 현황 진단 (조사 결과)
+
+### 설정
+- `next.config.ts`: AVIF/WebP, `deviceSizes`/`imageSizes` 설정됨. **`minimumCacheTTL` 미설정**, **`quality` 기본 75**.
+- `app/layout.tsx`: 폰트는 `next/font`(self-host, 양호). **`preconnect`/`dns-prefetch` 없음**.
+
+### 이미지 렌더 경로별 누락
+| 컴포넌트 | 소스 | URL 필드 | sizes | priority | 비고 |
+|---|---|---|---|---|---|
+| `ModalImage`→`FadeInImage`(ui) | next/image | `url`(원본 1920px) | ✅ | ✅(첫 이미지) | PR #50 완료 |
+| `WorkTitleButton`(메인 리스트) | next/image fill | `thumbnailUrl`(300px) | ✅`80px` | ❌ | 홈 첫 썸네일 priority 필요 |
+| `FloatingWorkWindow` | next/image fill | `thumbnailUrl` | ✅`80px` | ❌ | 호버 즉시표시용 priority |
+| `HomeIcon` | next/image fill | icon url | ❌ | ✅ | `sizes="48px"` 필요 |
+| `ImageZoomOverlay` | **원시 `<img>`** | `url`(원본 직접) | — | — | next/image 미적용·캐시 우회 |
+| `YouTubeEmbed` 썸네일 | **원시 `<img>`** | youtube img | — | — | 최적화 우회 |
+| `FadeInImage`(components 중복본) | next/image | props | ❌ | — | dead code, 배럴 미export |
+
+### 데이터/원본 스펙 (admin)
+- 원본: max 1920px, quality 0.9, WebP/JPEG → `/works-images/`
+- 썸네일: max 300px, quality 0.7, WebP/JPEG → `/works-thumbnails/`
+- `listThumbnailUrl`, `webpUrl` 필드는 타입에만 존재, **생성 안 됨**(미사용).
+
+---
+
+## 3. 개선 레버 (효과 · 위험 · 노력)
+
+### Tier A — front-only, 무위험, 즉시 (10x의 핵심)
+1. **`minimumCacheTTL` 설정** — 옵티마이저 결과를 엣지에 오래 보관 → 콜드 미스 → 웜 히트. **최대 레버.**
+2. **`quality` 하향** — 모달 원본 이미지 quality 75 → ~55(AVIF). 전송량 30~50%↓, 시각 차이 미미.
+3. **`preconnect`/`dns-prefetch`** — `firebasestorage.googleapis.com`(원본 직접 로드 경로) 첫 연결 지연 제거.
+4. **메인 리스트 첫 N개 썸네일 `priority`** — 홈 LCP 개선.
+5. **`HomeIcon` `sizes="48px"`** — fill 힌트 보강.
+
+### Tier B — front 구조 변경, 저위험
+6. **`ImageZoomOverlay` → `next/image`** — 줌 원본도 최적화·캐시 적용(단, 줌은 디테일 필요 → `quality` 별도/높게, `sizes="100vw"`).
+7. **`YouTubeEmbed` 썸네일 → `next/image`** (`loading="lazy"`).
+8. **인접 작품 이미지 prefetch** — 모달 열람 중 다음/이전 작품 이미지 `<link rel="prefetch">` 또는 router prefetch. (동작 무변경, 선로딩만)
+
+### Tier C — admin 파이프라인 변경 (보류 확정)
+9. ~~중간 변형(`listThumbnailUrl`) admin 사전생성~~ → **보류.** 클라이언트가 런타임 화면맞춤("유도리")을 선호하고, Vercel 옵티마이저가 이미 즉석 변형을 생성하므로 한계효용이 작다. 재업로드/마이그레이션 비용 대비 불필요.
+
+---
+
+## 4. 실행 단계 (Phase별 commit + 체크)
+
+각 Phase 완료 시 `npm run lint` + `npm run build` 통과 확인 후 commit, 체크박스 갱신.
+
+- [x] **Phase 6 — `next.config.ts` 캐시·품질 강화** (Tier A-1, A-2)
+  - `minimumCacheTTL` 명시(31일). 새 업로드=새 UUID URL이라 즉시 반영 안전(§0-1).
+  - `images.qualities`에 사용할 값 등록(Next 16) + `FadeInImage`/`ModalImage`에 `quality` prop 추가, 모달 본문에 **보수적 72** 적용. **줌(`ImageZoomOverlay`) 제외 — 원본 유지.**
+- [ ] **Phase 7 — preconnect/dns-prefetch** (Tier A-3)
+  - `layout.tsx`에 `firebasestorage.googleapis.com` preconnect + dns-prefetch (줌·YouTube 원본 직접 로드 가속).
+- [ ] **Phase 8 — 메인 리스트/아이콘 우선순위·힌트** (Tier A-4, A-5)
+  - `WorkTitleButton` 홈 첫 N개 `priority`, `HomeIcon` `sizes="48px"`.
+- [ ] **Phase 9 — `YouTubeEmbed` 썸네일 `next/image`화** (Tier B-7)
+  - **`ImageZoomOverlay`는 제외**(원본 보존, §0-3). YouTube 썸네일만 `next/image`(`loading="lazy"`).
+- [ ] **Phase 10 — 인접 이미지 prefetch** (Tier B-8)
+- [ ] **Phase 11 — 측정·검증**
+  - Lighthouse(모바일/데스크톱) LCP, Network 탭 이미지 전송량·요청수, 옵티마이저 캐시 `x-vercel-cache` HIT/MISS 비교(전/후).
+
+---
+
+## 5. 검증 방법
+
+- **Lighthouse**: LCP, "Properly size images", "Efficiently encode images", "Preconnect to required origins" 항목 전/후.
+- **Network**: 모달 1개 열람 시 총 이미지 바이트·요청 수, AVIF 변환 여부.
+- **캐시**: `/_next/image` 응답의 `x-vercel-cache`(HIT/MISS), `cache-control` 헤더로 워밍 확인.
+- **회귀**: 줌 디테일, 썸네일 화질, 스켈레톤/fade-in 동작 시각 확인(AS-IS 유지).
+
+---
+
+## 6. 기대 효과
+
+| 항목 | 변경 전 | 변경 후 |
+|---|---|---|
+| 옵티마이저 캐시 | 콜드 미스 반복 | 웜 히트(재방문/2차) → **체감 10~20x** |
+| 콜드 1차 LCP | baseline | preconnect+priority+quality → **3~5x** |
+| 모달 전송량 | PR #50 기준 | quality 튜닝 → 추가 **30~50%↓** |
+| 데이터 재업로드 | — | **불필요** (전 범위 front-only, admin 무변경) |
+| 새 업로드 즉시 반영 | 보장 | **보장 유지** (새 UUID URL, §0-1) |


### PR DESCRIPTION
## 배경

클라이언트 피드백 2건을 한 트랙에서 처리한다.
1. (1차) "이미지 로딩이 느리다" — 특히 모바일 모달.
2. (2차) "웹 버전 이미지 로딩 속도를 현재보다 **10x** 개선" — 웹/모바일 모두.

front는 Vercel에 배포되어(`vercel.json` + `next start`, `output: export` 아님) **Next.js 이미지 최적화가 프로덕션에서 완전히 동작**한다. 그럼에도 (a) 모달 본문 이미지에 `sizes` 힌트가 없어 모바일이 원본(최대 1920px, DPR에 따라 ~3840px)을 그대로 받고, (b) `minimumCacheTTL` 부재로 Vercel 옵티마이저가 매 요청마다 **Firebase 원본 fetch + AVIF 재인코딩(콜드 미스)**을 반복하던 것이 핵심 병목이었다.

> **제약(클라이언트 확정)**: ① 새 사진 업로드 시 **즉시 반영(타협 불가)** ② 품질 저하 최소화 ③ **확대(줌)는 무조건 원본** ④ 일반 보기는 화면맞춤 resize. 모든 변경은 **AS-IS 동작/비즈니스 로직 무변경**의 순수 성능 최적화이며, Firestore 데이터·admin 업로드 로직·재업로드는 **불필요**.

## "10x"의 정의

단일 이미지 1회 전송량을 추가로 10배 줄이는 것은 물리적으로 불가능(AVIF + 정확한 `sizes`로 이미 하한 근접). 따라서 10x는 **체감 로드 시간(LCP)** 기준으로 정의한다.

| 시나리오 | 달성 레버 | 기대 |
|---|---|---|
| 재방문/2차 사용자 (웜 캐시) | `minimumCacheTTL` (옵티마이저 캐시 워밍) | **10~20x** |
| 콜드 1차 로드 | quality 튜닝 + preconnect + priority | **3~5x** |
| 전송량(payload) | `sizes` + AVIF + quality | 모바일 **70~85%↓**, 추가 30~50%↓ |

## 변경 사항 (Phase별)

### Track 1 — 모바일 모달 과대 전송 제거 (Phase 1–5, 리뷰 반영 포함)
| Phase | 내용 |
|---|---|
| 1 | `next.config.ts` — `formats: [avif, webp]`, `deviceSizes`/`imageSizes` 명시 |
| 2 | `FadeInImage`·`ModalImage`에 `sizes` 전달 (**핵심 병목 해결**) — 모바일 100vw, 데스크톱 60vw |
| 3 | 모달 첫 이미지에 `priority` → LCP 개선 (리뷰 반영: 첫 미디어가 아닌 **첫 이미지** index로 수정) |
| 4 | `FloatingWorkWindow` `<img>` → `next/image` (`fill` + `sizes="80px"`) |

### Track 2 — 웹 10x (LCP 중심, Phase 6–11)
| Phase | 내용 |
|---|---|
| 6 | `minimumCacheTTL` 31일 — 옵티마이저 변환 결과를 엣지에 장기 보관해 **콜드 미스 반복 제거**. 새 업로드는 새 UUID URL → 캐시 키가 달라 **즉시 반영 보장**. `images.qualities` 등록 + 모달 본문 `quality 72`(화질 보존 우선, **줌은 원본 직접 로드라 영향 없음**) |
| 7 | `firebasestorage.googleapis.com`·`img.youtube.com` **preconnect/dns-prefetch** — 외부 직접 로드의 DNS+TLS 핸드셰이크 선제거 |
| 8 | 홈 첫 4개 썸네일 `priority`(`WorkListScrollerFlex` index 기준), `HomeIcon` `sizes` 추가 |
| 9 | `YouTubeEmbed` 썸네일 원시 `<img>` → `next/image`(`fill`+`sizes`), `maxres`→`hq` `onError` 폴백. **줌 오버레이는 원본 보존 위해 의도적 제외** |
| 10 | 호버 시 작품 상세 데이터 `usePrefetchWork` — 모달 진입 시 Firestore 왕복(스피너) 없이 즉시 렌더 → priority LCP 이미지 조기 로드 |

## 핵심 효과

- `sizes` 미지정 시 next/image가 원본 width 1x/2x srcSet만 생성하여 모바일이 1920~3840px를 받던 문제 해결 → 화면 폭 맞춤 **AVIF** 즉석 제공.
- `minimumCacheTTL`로 콜드 미스(원본 fetch + 재인코딩, 수백ms~수초)를 웜 히트로 전환 → 재방문 체감 대폭 개선.
- **데이터/재업로드 불필요** — 전 범위 front 렌더링 힌트·설정에 국한, admin 무변경.
- **새 업로드 즉시 반영 유지** — admin이 업로드마다 `uuidv4()`로 새 URL 생성(`admin/src/data/api/storageApi.ts:62`)하므로 `minimumCacheTTL`을 길게 잡아도 안전.

## 검증

- 전 Phase `npm run build` → `✓ Compiled successfully`, TypeScript 통과. 변경 파일 `eslint` 0 errors.
- preconnect/dns-prefetch가 prerender HTML·서버 응답에 정상 포함 확인.
- **iOS 시뮬레이터(iPhone 17 Pro) 모바일 Safari 구동 확인** — 모바일 레이아웃 활성, 셸/카테고리/폰트 정상.
- ⚠️ AVIF 변환·`Cache-Control`(`minimumCacheTTL`)·`x-vercel-cache` MISS→HIT 실측은 **로컬 sandbox 네트워크 차단으로 불가** → 아래 프로덕션 체크리스트로 배포 후 수행.

### 프로덕션 측정 체크리스트 (배포 후)
- **Lighthouse**: LCP, "Properly size images", "Efficiently encode images", "Preconnect to required origins" 전/후 비교.
- **Network**: 모달 1개 열람 시 총 이미지 바이트·요청 수, 응답 `content-type: image/avif`.
- **캐시**: `/_next/image` 응답의 `x-vercel-cache`(MISS→HIT 전환), `cache-control` `max-age`가 `minimumCacheTTL` 반영 여부.
- **회귀(AS-IS 유지)**: 줌 디테일(원본), 썸네일/모달 화질, 스켈레톤/fade-in, **새 업로드 즉시 반영**.

## 보류 항목 (별도 트랙)

- Tier C(admin medium 변형 `listThumbnailUrl` 사전생성) — 클라이언트가 런타임 화면맞춤("유도리")을 선호하고 Vercel 옵티마이저가 이미 즉석 변형을 생성하므로 한계효용 작음 → **보류 확정**.
- 미사용 필드(`listThumbnailUrl`/`webpUrl`)·중복 `components/media/FadeInImage.tsx` 정리, `dangerouslyAllowSVG` 재검토, blur placeholder 도입.

계획 문서: `tasks/image-optimization-plan.md`, `tasks/web-image-speed-10x-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
