### PR TITLE
feat: 이미지 단위 캡션 기능 추가

### DIFF
--- a/admin/src/__tests__/components/ImageUploader.caption.test.tsx
+++ b/admin/src/__tests__/components/ImageUploader.caption.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageUploader from '../../components/ImageUploader';
+import type { WorkImage } from '../../core/types';
+
+// antd message만 모킹 (나머지는 실제 컴포넌트 사용)
+vi.mock('antd', async () => {
+  const actual = await vi.importActual('antd');
+  return {
+    ...actual,
+    message: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+  };
+});
+
+const image: WorkImage = {
+  id: 'img-1',
+  url: 'https://example.com/a.jpg',
+  thumbnailUrl: 'https://example.com/a-t.jpg',
+  order: 0,
+  width: 800,
+  height: 600,
+};
+
+describe('ImageUploader 캡션 편집', () => {
+  it('모달에서 캡션 입력 후 확인하면 onChange로 caption이 반영된다', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ImageUploader value={[image]} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /캡션 편집/ }));
+    const textarea = await screen.findByPlaceholderText(/사진 캡션/);
+    await user.type(textarea, '사진_XXX');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 'img-1', caption: '사진_XXX' })])
+      );
+    });
+  });
+
+  it('취소하면 캡션이 반영되지 않는다', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ImageUploader value={[image]} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /캡션 편집/ }));
+    const textarea = await screen.findByPlaceholderText(/사진 캡션/);
+    await user.type(textarea, '버려질 캡션');
+    await user.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('기존 캡션은 카드에 미리보기로 표시된다', () => {
+    render(<ImageUploader value={[{ ...image, caption: '사진_XXX' }]} onChange={vi.fn()} />);
+    expect(screen.getByText('사진_XXX')).toBeInTheDocument();
+  });
+
+  it('캡션이 없으면 "캡션 없음"을 표시한다', () => {
+    render(<ImageUploader value={[image]} onChange={vi.fn()} />);
+    expect(screen.getByText('캡션 없음')).toBeInTheDocument();
+  });
+});

--- a/admin/src/__tests__/core/utils/imageUploadMerge.test.ts
+++ b/admin/src/__tests__/core/utils/imageUploadMerge.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { mergeUploadedImages } from '../../../core/utils/imageUploadMerge';
+import type { WorkImage } from '../../../core/types';
+
+const tempImage = (id: string, caption?: string): WorkImage => ({
+  id,
+  url: 'blob:preview',
+  thumbnailUrl: 'blob:preview',
+  order: 1,
+  width: 0,
+  height: 0,
+  ...(caption !== undefined ? { caption } : {}),
+});
+
+const uploadedImage = (id: string): WorkImage => ({
+  id,
+  url: `https://cdn/${id}.jpg`,
+  thumbnailUrl: `https://cdn/${id}-t.jpg`,
+  order: 1,
+  width: 800,
+  height: 600,
+});
+
+describe('mergeUploadedImages', () => {
+  it('🔴 회귀: 신규 업로드 이미지의 caption이 업로드 결과 병합 후에도 보존된다', () => {
+    const temp = tempImage('pending-1', '사진_XXX');
+    const real = uploadedImage('real-1');
+    const uploadedMap = new Map([['pending-1', real]]);
+
+    const { images } = mergeUploadedImages([temp], uploadedMap, new Set(), 'pending-1');
+
+    expect(images).toHaveLength(1);
+    // 실제 업로드 결과 URL로 교체되었지만 caption은 temp에서 승계
+    expect(images[0].url).toBe('https://cdn/real-1.jpg');
+    expect(images[0].caption).toBe('사진_XXX');
+  });
+
+  it('caption이 없는 신규 이미지는 caption이 undefined로 유지된다', () => {
+    const temp = tempImage('pending-1');
+    const uploadedMap = new Map([['pending-1', uploadedImage('real-1')]]);
+
+    const { images } = mergeUploadedImages([temp], uploadedMap, new Set(), 'pending-1');
+
+    expect(images[0].caption).toBeUndefined();
+  });
+
+  it('이미 업로드된(교체 대상 아님) 이미지의 caption은 그대로 유지된다', () => {
+    const existing: WorkImage = { ...uploadedImage('real-existing'), caption: '기존캡션' };
+    const { images } = mergeUploadedImages([existing], new Map(), new Set(), 'real-existing');
+
+    expect(images[0].caption).toBe('기존캡션');
+  });
+
+  it('업로드 실패한 이미지는 제거되고 order가 재정렬된다', () => {
+    const ok = tempImage('p-ok', 'A');
+    const fail = tempImage('p-fail', 'B');
+    const uploadedMap = new Map([['p-ok', uploadedImage('real-ok')]]);
+    const failed = new Set(['p-fail']);
+
+    const { images } = mergeUploadedImages([ok, fail], uploadedMap, failed, 'p-ok');
+
+    expect(images).toHaveLength(1);
+    expect(images[0].caption).toBe('A');
+    expect(images[0].order).toBe(1);
+  });
+
+  it('썸네일이 temp였다면 실제 ID로 교체된다', () => {
+    const temp = tempImage('pending-1', 'cap');
+    const uploadedMap = new Map([['pending-1', uploadedImage('real-1')]]);
+
+    const { thumbnailId } = mergeUploadedImages([temp], uploadedMap, new Set(), 'pending-1');
+
+    expect(thumbnailId).toBe('real-1');
+  });
+});

--- a/admin/src/__tests__/data/api/worksApi.imageCaption.test.ts
+++ b/admin/src/__tests__/data/api/worksApi.imageCaption.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Work, WorkImage } from '../../../core/types';
+
+// Firebase 모킹 — 검증 실패는 addDoc 이전에 발생하므로 모듈 로드만 통과시키면 됨
+vi.mock('../../../data/api/client', () => ({ db: {} }));
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({})),
+  doc: vi.fn(() => ({})),
+  getDocs: vi.fn(),
+  getDoc: vi.fn(async () => ({ data: () => ({}) })),
+  addDoc: vi.fn(async () => ({ id: 'new-id' })),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(),
+  orderBy: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+  startAfter: vi.fn(),
+  serverTimestamp: vi.fn(() => 'ts'),
+}));
+
+import { createWork } from '../../../data/api/worksApi';
+import { ValidationError } from '../../../core/errors';
+
+const makeImage = (caption?: string): WorkImage => ({
+  id: 'img-1',
+  url: 'https://example.com/a.jpg',
+  thumbnailUrl: 'https://example.com/a-t.jpg',
+  order: 0,
+  width: 800,
+  height: 600,
+  ...(caption !== undefined ? { caption } : {}),
+});
+
+const makeWork = (images: WorkImage[]): Omit<Work, 'id' | 'createdAt' | 'updatedAt'> => ({
+  title: 'Test',
+  thumbnailImageId: 'img-1',
+  images,
+  videos: [],
+  sentenceCategoryIds: [],
+  exhibitionCategoryIds: [],
+  isPublished: false,
+});
+
+describe('worksApi 이미지 캡션 검증', () => {
+  it('이미지 캡션이 200자를 초과하면 ValidationError(IMAGE_CAPTION_TOO_LONG)', async () => {
+    const work = makeWork([makeImage('x'.repeat(201))]);
+    await expect(createWork(work)).rejects.toMatchObject({
+      name: 'ValidationError',
+      code: 'IMAGE_CAPTION_TOO_LONG',
+    });
+  });
+
+  it('이미지 캡션이 200자 이하이면 캡션 검증을 통과한다', async () => {
+    const work = makeWork([makeImage('x'.repeat(200))]);
+    // 검증 통과 → 모킹된 Firebase 경로로 정상 resolve
+    await expect(createWork(work)).resolves.toBeDefined();
+  });
+
+  it('캡션이 없는 이미지는 검증을 통과한다', async () => {
+    const work = makeWork([makeImage(undefined)]);
+    await expect(createWork(work)).resolves.toBeDefined();
+  });
+});
+
+// ValidationError 임을 함께 보장
+describe('worksApi 이미지 캡션 검증 - 에러 타입', () => {
+  it('초과 시 던져지는 에러는 ValidationError 인스턴스', async () => {
+    const work = makeWork([makeImage('x'.repeat(201))]);
+    await createWork(work).catch((e) => {
+      expect(e).toBeInstanceOf(ValidationError);
+    });
+  });
+});

--- a/admin/src/__tests__/data/mappers/workMapper.test.ts
+++ b/admin/src/__tests__/data/mappers/workMapper.test.ts
@@ -126,6 +126,23 @@ describe('workMapper', () => {
       expect(result.images[2].order).toBe(1);
     });
 
+    it('should preserve per-image caption through mapping', () => {
+      const dataWithImageCaptions = {
+        title: 'Test',
+        images: [
+          { id: 'img-1', url: 'url1', thumbnailUrl: 'thumb1', order: 0, caption: '사진_나혜빈' },
+          { id: 'img-2', url: 'url2', thumbnailUrl: 'thumb2', order: 1 },
+        ],
+        createdAt: mockTimestamp,
+        updatedAt: mockTimestamp,
+      };
+
+      const result = mapFirestoreToWork('work-caption', dataWithImageCaptions);
+
+      expect(result.images[0].caption).toBe('사진_나혜빈');
+      expect(result.images[1].caption).toBeUndefined();
+    });
+
     it('should handle boolean isPublished correctly', () => {
       const publishedData = {
         title: 'Published Work',

--- a/admin/src/__tests__/data/mappers/workMapper.test.ts
+++ b/admin/src/__tests__/data/mappers/workMapper.test.ts
@@ -130,7 +130,7 @@ describe('workMapper', () => {
       const dataWithImageCaptions = {
         title: 'Test',
         images: [
-          { id: 'img-1', url: 'url1', thumbnailUrl: 'thumb1', order: 0, caption: '사진_나혜빈' },
+          { id: 'img-1', url: 'url1', thumbnailUrl: 'thumb1', order: 0, caption: '사진_XXX' },
           { id: 'img-2', url: 'url2', thumbnailUrl: 'thumb2', order: 1 },
         ],
         createdAt: mockTimestamp,
@@ -139,7 +139,7 @@ describe('workMapper', () => {
 
       const result = mapFirestoreToWork('work-caption', dataWithImageCaptions);
 
-      expect(result.images[0].caption).toBe('사진_나혜빈');
+      expect(result.images[0].caption).toBe('사진_XXX');
       expect(result.images[1].caption).toBeUndefined();
     });
 

--- a/admin/src/components/ImageUploader.css
+++ b/admin/src/components/ImageUploader.css
@@ -48,6 +48,23 @@
   overflow: hidden;
 }
 
+.image-caption-area {
+  margin-bottom: 12px;
+}
+
+.image-caption-preview.ant-typography {
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #595959;
+}
+
+.image-caption-empty {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #bfbfbf;
+}
+
 .image-actions {
   display: flex;
   flex-direction: column;

--- a/admin/src/components/ImageUploader.tsx
+++ b/admin/src/components/ImageUploader.tsx
@@ -47,6 +47,9 @@ const ImageUploader = ({
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [compressOriginal, setCompressOriginal] = useState(true);
+  // 캡션 편집 모달 상태 (편집 중인 이미지 + 임시 입력값)
+  const [captionEditing, setCaptionEditing] = useState<{ imageId: string; index: number } | null>(null);
+  const [captionDraft, setCaptionDraft] = useState('');
 
   // value가 변경되면 images도 업데이트
   useEffect(() => {
@@ -163,10 +166,6 @@ const ImageUploader = ({
     setImages(newImages);
     onChange?.(newImages);
   };
-
-  // 캡션 편집 모달 상태 (편집 중인 이미지 + 임시 입력값)
-  const [captionEditing, setCaptionEditing] = useState<{ imageId: string; index: number } | null>(null);
-  const [captionDraft, setCaptionDraft] = useState('');
 
   const openCaptionEditor = (imageId: string, index: number) => {
     const target = images.find((img) => img.id === imageId);
@@ -355,7 +354,6 @@ const ImageUploader = ({
                   <Typography.Paragraph
                     className="image-caption-preview"
                     ellipsis={{ rows: 2, tooltip: image.caption }}
-                    title={image.caption}
                   >
                     {image.caption}
                   </Typography.Paragraph>

--- a/admin/src/components/ImageUploader.tsx
+++ b/admin/src/components/ImageUploader.tsx
@@ -429,7 +429,7 @@ const ImageUploader = ({
         onCancel={closeCaptionEditor}
         okText="확인"
         cancelText="취소"
-        destroyOnClose
+        destroyOnHidden
       >
         <Input.TextArea
           autoFocus

--- a/admin/src/components/ImageUploader.tsx
+++ b/admin/src/components/ImageUploader.tsx
@@ -1,6 +1,6 @@
 // 이미지 선택 및 관리 컴포넌트 (Storage 업로드는 부모에서 저장 시 수행)
 import { useState, useEffect, useRef } from 'react';
-import { Upload, Image, Button, Space, Card, message, Switch, Tooltip } from 'antd';
+import { Upload, Image, Button, Space, Card, message, Switch, Tooltip, Input, Modal, Typography } from 'antd';
 import { DragOutlined, CompressOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
 import {
@@ -10,8 +10,10 @@ import {
   UpOutlined,
   DownOutlined,
   BulbOutlined,
+  EditOutlined,
 } from '@ant-design/icons';
 import type { WorkImage } from '../core/types';
+import { appConfig } from '../core/constants/config';
 import './ImageUploader.css';
 
 const { Dragger } = Upload;
@@ -151,6 +153,34 @@ const ImageUploader = ({
     }
 
     message.success('이미지가 목록에서 제거되었습니다.');
+  };
+
+  // 이미지 캡션 변경 (상세 화면에서 이미지 아래 표시될 텍스트)
+  const handleCaptionChange = (imageId: string, caption: string) => {
+    const newImages = images.map((img) =>
+      img.id === imageId ? { ...img, caption } : img
+    );
+    setImages(newImages);
+    onChange?.(newImages);
+  };
+
+  // 캡션 편집 모달 상태 (편집 중인 이미지 + 임시 입력값)
+  const [captionEditing, setCaptionEditing] = useState<{ imageId: string; index: number } | null>(null);
+  const [captionDraft, setCaptionDraft] = useState('');
+
+  const openCaptionEditor = (imageId: string, index: number) => {
+    const target = images.find((img) => img.id === imageId);
+    setCaptionDraft(target?.caption ?? '');
+    setCaptionEditing({ imageId, index });
+  };
+
+  const closeCaptionEditor = () => setCaptionEditing(null);
+
+  const submitCaptionEditor = () => {
+    if (captionEditing) {
+      handleCaptionChange(captionEditing.imageId, captionDraft.trim());
+    }
+    closeCaptionEditor();
   };
 
   // 이미지 순서 변경 (위로)
@@ -320,6 +350,30 @@ const ImageUploader = ({
                   style={{ objectFit: 'cover', borderRadius: '4px' }}
                 />
               </div>
+              <div className="image-caption-area">
+                {image.caption ? (
+                  <Typography.Paragraph
+                    className="image-caption-preview"
+                    ellipsis={{ rows: 2, tooltip: image.caption }}
+                    title={image.caption}
+                  >
+                    {image.caption}
+                  </Typography.Paragraph>
+                ) : (
+                  <span className="image-caption-empty">캡션 없음</span>
+                )}
+                <Button
+                  size="small"
+                  icon={<EditOutlined />}
+                  block
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openCaptionEditor(image.id, index);
+                  }}
+                >
+                  캡션 편집
+                </Button>
+              </div>
               <div className="image-actions">
                 <Space direction="vertical" size="small" style={{ width: '100%' }}>
                   <Space size="small" style={{ width: '100%' }}>
@@ -366,6 +420,37 @@ const ImageUploader = ({
           <BulbOutlined /> 위/아래 버튼으로 순서를 변경할 수 있습니다
         </div>
       )}
+
+      {/* 캡션 편집 모달 */}
+      <Modal
+        title={captionEditing ? `이미지 #${captionEditing.index + 1} 캡션` : '캡션'}
+        open={captionEditing !== null}
+        onOk={submitCaptionEditor}
+        onCancel={closeCaptionEditor}
+        okText="확인"
+        cancelText="취소"
+        destroyOnClose
+      >
+        <Input.TextArea
+          autoFocus
+          placeholder="사진 캡션 (선택, 예: 사진_나혜빈)"
+          maxLength={appConfig.text.imageCaptionMaxLength}
+          showCount
+          autoSize={{ minRows: 3, maxRows: 8 }}
+          value={captionDraft}
+          onChange={(e) => setCaptionDraft(e.target.value)}
+          onPressEnter={(e) => {
+            // Enter=저장, Shift+Enter=줄바꿈
+            if (!e.shiftKey) {
+              e.preventDefault();
+              submitCaptionEditor();
+            }
+          }}
+        />
+        <p style={{ marginTop: 8, marginBottom: 0, color: '#8c8c8c', fontSize: 12 }}>
+          상세 화면에서 이미지 아래 우측에 표시됩니다. 비워두면 표시되지 않습니다.
+        </p>
+      </Modal>
     </div>
   );
 };

--- a/admin/src/components/ImageUploader.tsx
+++ b/admin/src/components/ImageUploader.tsx
@@ -433,7 +433,7 @@ const ImageUploader = ({
       >
         <Input.TextArea
           autoFocus
-          placeholder="사진 캡션 (선택, 예: 사진_나혜빈)"
+          placeholder="사진 캡션 (선택, 예: 사진_XXX)"
           maxLength={appConfig.text.imageCaptionMaxLength}
           showCount
           autoSize={{ minRows: 3, maxRows: 8 }}

--- a/admin/src/core/constants/config.ts
+++ b/admin/src/core/constants/config.ts
@@ -42,6 +42,7 @@ export const appConfig = {
   // 텍스트 제한
   text: {
     captionMaxLength: 1000,
+    imageCaptionMaxLength: 200,
     titleMaxLength: 200,
     descriptionMaxLength: 5000,
   },

--- a/admin/src/core/types/api.ts
+++ b/admin/src/core/types/api.ts
@@ -28,6 +28,8 @@ export interface WorkImage {
   height: number;
   fileSize?: number;
   uploadedFrom?: 'desktop' | 'mobile' | 'camera';
+  /** 이미지 단위 캡션 (상세 화면에서 이미지 아래 한 줄로 표시, 선택값) */
+  caption?: string;
 }
 
 /**

--- a/admin/src/core/utils/imageUploadMerge.ts
+++ b/admin/src/core/utils/imageUploadMerge.ts
@@ -1,0 +1,45 @@
+import type { WorkImage } from '../types';
+
+/**
+ * 업로드 완료된 이미지를 현재 이미지 목록에 병합한다.
+ *
+ * - temp(pending) 이미지는 업로드 결과(real)로 교체하되,
+ *   사용자가 입력한 `order`/`caption`은 temp 이미지에서 그대로 승계한다.
+ *   (real에는 caption 정보가 없으므로 승계하지 않으면 신규 업로드 이미지의 캡션이 소실된다)
+ * - 업로드 실패한 temp 이미지는 목록에서 제거한다.
+ * - 최종 목록은 order를 1부터 재정렬한다.
+ * - 썸네일 ID가 temp였다면 실제 ID로 교체하고, 실패한 경우 첫 이미지로 대체한다.
+ */
+export const mergeUploadedImages = (
+  currentImages: WorkImage[],
+  uploadedMap: Map<string, WorkImage>,
+  failedTempIds: Set<string>,
+  currentThumbnailId: string
+): { images: WorkImage[]; thumbnailId: string } => {
+  const finalImages = currentImages
+    .map((img) => {
+      const real = uploadedMap.get(img.id);
+      if (real) {
+        // 업로드 결과(real)로 교체하되, 사용자 입력값(order/caption)은 temp 이미지에서 승계
+        return { ...real, order: img.order, caption: img.caption };
+      }
+      // 업로드 실패한 pending 이미지는 제거
+      if (failedTempIds.has(img.id)) {
+        return null;
+      }
+      return img;
+    })
+    .filter((img): img is WorkImage => img !== null)
+    .map((img, idx) => ({ ...img, order: idx + 1 }));
+
+  let finalThumbnailId = currentThumbnailId;
+  const realThumb = uploadedMap.get(currentThumbnailId);
+  if (realThumb) {
+    finalThumbnailId = realThumb.id;
+  }
+  if (failedTempIds.has(currentThumbnailId) && finalImages.length > 0) {
+    finalThumbnailId = finalImages[0].id;
+  }
+
+  return { images: finalImages, thumbnailId: finalThumbnailId };
+};

--- a/admin/src/core/utils/index.ts
+++ b/admin/src/core/utils/index.ts
@@ -4,3 +4,4 @@ export * from './string';
 export * from './date';
 export * from './validation';
 export * from './logger';
+export * from './imageUploadMerge';

--- a/admin/src/data/api/worksApi.ts
+++ b/admin/src/data/api/worksApi.ts
@@ -55,6 +55,21 @@ const validateWorkData = (
     );
   }
 
+  // 이미지 캡션 길이 검사 (이미지별 한 줄 캡션)
+  if (work.images !== undefined) {
+    const tooLong = work.images.some(
+      (img) =>
+        img.caption !== undefined &&
+        img.caption.length > appConfig.text.imageCaptionMaxLength
+    );
+    if (tooLong) {
+      throw new ValidationError(
+        `이미지 캡션은 ${appConfig.text.imageCaptionMaxLength}자를 초과할 수 없습니다.`,
+        'IMAGE_CAPTION_TOO_LONG'
+      );
+    }
+  }
+
   // 연도 유효성 검사
   if (work.year !== undefined && work.year !== null) {
     const currentYear = new Date().getFullYear();

--- a/admin/src/pages/WorkForm.tsx
+++ b/admin/src/pages/WorkForm.tsx
@@ -29,6 +29,7 @@ import MediaOrderManager from '../components/MediaOrderManager';
 import CaptionEditor from '../components/CaptionEditor';
 import { deleteWorkImages, uploadImage } from '../data/repository';
 import { getErrorDisplayInfo, logErrorForDev } from '../core/utils/errorMessages';
+import { mergeUploadedImages } from '../core/utils/imageUploadMerge';
 import './WorkForm.css';
 
 const { Title } = Typography;
@@ -274,34 +275,14 @@ const WorkForm = () => {
       });
     }
 
-    // temp 이미지를 실제 업로드 결과로 교체, 실패한 것은 제거
+    // temp 이미지를 실제 업로드 결과로 교체(caption/order 승계), 실패한 것은 제거, 썸네일 보정
     const failedIds = new Set(failedPending.map((p) => p.tempId));
-    const finalImages = currentImages
-      .map((img) => {
-        const real = uploadedMap.get(img.id);
-        if (real) {
-          // 업로드 결과(real)로 교체하되, 사용자가 입력한 order/caption은 임시 이미지(img)에서 승계
-          return { ...real, order: img.order, caption: img.caption };
-        }
-        // 실패한 pending 이미지는 제거
-        if (failedIds.has(img.id)) {
-          return null;
-        }
-        return img;
-      })
-      .filter((img): img is WorkImage => img !== null)
-      .map((img, idx) => ({ ...img, order: idx + 1 })); // order 재정렬
-
-    // 썸네일 ID가 pending이었다면 실제 ID로 교체
-    let finalThumbnailId = currentThumbnailId;
-    const realThumb = uploadedMap.get(currentThumbnailId);
-    if (realThumb) {
-      finalThumbnailId = realThumb.id;
-    }
-    // 썸네일이 실패한 이미지였다면 첫 번째 이미지로 대체
-    if (failedIds.has(currentThumbnailId) && finalImages.length > 0) {
-      finalThumbnailId = finalImages[0].id;
-    }
+    const { images: finalImages, thumbnailId: finalThumbnailId } = mergeUploadedImages(
+      currentImages,
+      uploadedMap,
+      failedIds,
+      currentThumbnailId
+    );
 
     // 실패한 파일은 pending에 남겨둠 (재시도 가능)
     setPendingImages(failedPending);

--- a/admin/src/pages/WorkForm.tsx
+++ b/admin/src/pages/WorkForm.tsx
@@ -280,7 +280,8 @@ const WorkForm = () => {
       .map((img) => {
         const real = uploadedMap.get(img.id);
         if (real) {
-          return { ...real, order: img.order };
+          // 업로드 결과(real)로 교체하되, 사용자가 입력한 order/caption은 임시 이미지(img)에서 승계
+          return { ...real, order: img.order, caption: img.caption };
         }
         // 실패한 pending 이미지는 제거
         if (failedIds.has(img.id)) {

--- a/docs/plans/IMAGE_CAPTION_PLAN.md
+++ b/docs/plans/IMAGE_CAPTION_PLAN.md
@@ -1,0 +1,205 @@
+# 이미지 캡션 기능 구현 계획
+
+> 작성일: 2026-06-22 (코드 검증 후 갱신)
+> 브랜치: `feature-image-caption`
+> 스펙 출처: 클라이언트(나혜빈) 요청 — `KakaoTalk_Photo_2026-06-22-22-20-53.jpeg`
+
+---
+
+## 1. 목표 (Goal)
+
+**카테고리(키워드)를 클릭해 진입하는 작품 상세 화면**에서, 세로로 나열되는 **각 이미지 아래에 한 줄짜리 캡션 텍스트**를 표시할 수 있게 한다.
+예: `사진_나혜빈` 같은 사진 출처/설명 문구.
+
+### 스펙 원문 요약
+
+> - "사진 아래쪽에 텍스트를 적을 수 있는 설정칸 한 줄이 필요합니다."
+> - "캡션과 같은 색, 이메일 적은 텍스트와 같은 폰트크기로."
+> - "사진마다 정보를 적을 수 있게 설정하되 공백으로 남겨두는 것도 가능하게 관리할 수 있으면 좋을 것 같습니다!"
+
+### 요구사항 분해
+
+| # | 요구사항 | 해석 |
+|---|----------|------|
+| R1 | 사진 아래 한 줄 텍스트 입력칸 | **이미지별** 단일 라인 plain text 캡션 필드 |
+| R2 | 캡션과 같은 색 | 색상 = 기존 작품 캡션 색상 (`var(--color-gray-700)`) |
+| R3 | 이메일 텍스트와 같은 폰트 크기 | 폰트 크기 = Footer 텍스트 (`var(--font-size-xs)`) |
+| R4 | 사진마다 설정 | 이미지 단위로 개별 입력 |
+| R5 | 공백 허용 | 선택값(optional), 빈 값이면 렌더링하지 않음 |
+
+### 노출 범위 (확정)
+
+- ✅ **작품 상세 화면의 이미지 목록에만** 표시 (PC `WorkModal` + 모바일 `WorkModalMobile`)
+- ❌ 작품 목록 썸네일에는 미표시
+- ❌ 이미지 클릭 시 뜨는 확대(zoom) 오버레이에는 미표시 (이미지만 확대)
+
+---
+
+## 2. 기존 구조와의 구분 (중요)
+
+이미 존재하는 `Work.caption`과 **혼동 금지**.
+
+| 구분 | 기존 `Work.caption` | 신규 이미지 캡션 (이번 작업) |
+|------|--------------------|------------------------------|
+| 단위 | 작품(work) 전체 1개 | 이미지마다 1개 |
+| 형식 | HTML 리치텍스트 (TipTap) | 단일 라인 plain text |
+| 내용 | 규격·재료·작품명 등 설명 | 사진 출처/짧은 캡션 |
+| 위치 | 상세 화면 우측 고정 영역 | 각 사진 바로 아래 |
+| 구현 상태 | 완료 | **미구현 (이번 작업)** |
+
+→ 신규 필드는 `WorkImage` 타입 안에 추가한다. (네스팅되어 있어 이름 충돌 없음)
+
+---
+
+## 3. 상세 화면 컴포넌트 계층 (코드 검증 완료 · ⚠️ 최초 분석 정정됨)
+
+> ⚠️ **중요 정정**: 처음엔 "메인 상세 = WorkModal → ModalImage"로 봤으나, 실제로는 **메인 상세 화면이 `WorkDetailPage` 안에서 이미지 목록을 직접 인라인 렌더**한다. `WorkModal`/`ModalImage`는 **캡션 링크로 다른 작품을 열 때 뜨는 보조 모달** 전용이다. 따라서 **두 경로 모두** 캡션을 넣어야 한다.
+
+```
+카테고리 클릭 → 작품 선택 → URL: /?keywordId=xxx&workId=123
+  app/page.tsx (workId 보고 조건부 렌더, :31-42)
+    └ app/works/WorkDetailPage.tsx
+        │
+        ├─ [메인 상세 화면] sortedMedia.map() 인라인 렌더 (:490-547)   ← ✅ 캡션 지점 ①
+        │     └ <div data-image-id> → ZoomableImage → FadeInImage
+        │       (PC·모바일 공용 — isMobile 분기 없음)
+        │
+        └─ [보조 모달] modalWorkId 있을 때만 (:567-580)              ← 연관 작품 클릭 시
+              ├ WorkModal (PC) / WorkModalMobile (모바일)
+              │   └ 이미지 목록 .map() → ModalImage                  ← ✅ 캡션 지점 ②
+              │         └ ZoomableImage → FadeInImage
+              └ (ZoomableImage 클릭 = 확대 오버레이, 캡션 제외)
+```
+
+- **캡션 추가 지점은 두 곳**:
+  ① `WorkDetailPage.tsx` 인라인 렌더 (메인 상세, PC·모바일 공용) — **이게 실제 진입 화면**
+  ② `ModalImage.tsx` (보조/연관작품 모달, PC·모바일 공용)
+- 캡션은 `ZoomableImage`(클릭 영역) **바깥, 이미지 아래**에 배치 → 캡션 클릭 시 확대 안 됨, 확대 오버레이에 캡션 미포함.
+- (디버깅 기록: `data-image-id`를 렌더하는 주체가 `ModalImage`가 아니라 `WorkDetailPage:514`임을 헤드리스 DOM 추적으로 확인하여 정정.)
+
+---
+
+## 4. 관련 파일 (검증된 경로/라인)
+
+### 타입 (양쪽 모두 수정)
+- `front/src/core/types/work.types.ts:3-14` — `WorkImage`
+- `admin/src/core/types/api.ts:20-31` — `WorkImage`
+
+### Admin 입력
+- `admin/src/components/ImageUploader.tsx` — 이미지 카드 그리드 (`:286-359`)
+- `admin/src/pages/WorkForm.tsx`
+  - 🔴 `:279-292` — pending→실제 이미지 **병합부 (caption 소실 버그 지점)**
+  - `:387` — `removeUndefinedValues(img)`로 저장 직전 undefined 제거 (빈 캡션 자동 정리)
+- `admin/src/data/api/worksApi.ts:34-65` — 유효성 검사
+- `admin/src/core/constants/config.ts:43-47` — `text` 상수 (`captionMaxLength` 등)
+
+### Front 표시 (두 곳)
+- ✅ ① `front/app/works/WorkDetailPage.tsx:511-545` 인라인 렌더 — **메인 상세 화면 (실제 진입 화면, PC·모바일 공용)**
+- ✅ ② `front/src/presentation/components/work/ModalImage.tsx` — 보조/연관작품 모달
+- 스타일 기준값:
+  - 색상 `var(--color-gray-700)` (기존 캡션, `WorkDetailPage.tsx` renderCaption)
+  - 폰트 `var(--font-size-xs)` (Footer 이메일 텍스트)
+  - 정렬 `text-align: right` (이미지 아래 **우측 정렬** — 클라이언트 확정)
+
+### Mapper — **변경 불필요 (검증 완료)**
+- 이미지 배열은 통째로 불투명하게 통과되므로 `WorkImage`에 필드만 추가하면 caption이 자동으로 흐른다.
+  - 쓰기: `admin/.../workMapper.ts:44` → `images: work.images`
+  - 읽기: `admin/.../workMapper.ts:20`, `front/.../workMapper.ts:16` → `images: (data.images as WorkImage[]) || []`
+
+---
+
+## 5. 설계 결정
+
+1. **데이터 모델**: `WorkImage`에 `caption?: string` 추가 (optional → R5 충족). 단일 라인 plain text.
+2. **저장 위치**: 이미지 객체 자체에 포함 → 순서 변경/삭제 시 캡션이 함께 따라감.
+   - 검증: `ImageUploader.tsx`의 reorder/delete는 모두 `{ ...img, order }` 스프레드(`:134, :161, :174, :210`)라 caption 보존됨.
+3. **입력 UI**: Ant Design `Input` (단일 라인), 각 이미지 카드 하단. `maxLength` 적용.
+4. **표시 위치**: 이미지 바로 아래, **우측 정렬**(`text-align: right`), 빈 값이면 DOM 미출력. 메인 상세(`WorkDetailPage` 인라인)와 보조 모달(`ModalImage`) **두 곳 모두** 적용. (오버레이 아님 — 흐름상 이미지 하단.)
+5. **이름**: `caption`으로 통일하되 주석으로 "이미지 단위 캡션"임을 명시.
+6. **길이 제한**: `text.imageCaptionMaxLength = 200` 신규 상수 추가.
+7. **undefined 처리**: 저장 직전 `removeUndefinedValues`(`WorkForm.tsx:387`)가 빈/미입력 캡션을 제거하므로 Firestore 직렬화 안전.
+
+---
+
+## 6. 구현 단계
+
+### Phase 1 — 타입 & 상수
+- [ ] `front/src/core/types/work.types.ts` `WorkImage`에 `caption?: string` 추가
+- [ ] `admin/src/core/types/api.ts` `WorkImage`에 `caption?: string` 추가
+- [ ] `admin/src/core/constants/config.ts` `text.imageCaptionMaxLength = 200` 추가
+
+> ℹ️ `PendingImage`(`ImageUploader.tsx:20-25`)에는 추가하지 않는다. 캡션은 미리보기용 임시 `WorkImage`(`:86`)에 저장되어 `images` 상태로 관리되는 것이 맞다. `PendingImage`는 업로드용 `File` 참조 전용.
+
+### Phase 2 — Admin 입력 UI
+- [ ] `admin/src/components/ImageUploader.tsx`: 각 이미지 카드(`:323` 액션 영역 부근)에 단일 라인 `Input` 추가
+  - placeholder 예: `"사진 캡션 (선택, 예: 사진_나혜빈)"`, `maxLength={200}`
+  - `onChange` → 해당 `images[index]`의 `caption` 갱신 후 `onChange(newImages)` 호출 (PendingImage 경로 아님)
+- [ ] `admin/src/pages/WorkForm.tsx`: 변경 감지(`hasChanges`, `:111-138`)에 이미지 캡션 변경 반영
+
+### Phase 3 — 🔴 저장 병합 버그 수정 (필수)
+- [ ] `admin/src/pages/WorkForm.tsx:283` — pending 이미지가 실제 이미지로 교체될 때 caption 승계
+  ```ts
+  // 현재 (caption 소실):
+  return { ...real, order: img.order };
+  // 수정:
+  return { ...real, order: img.order, caption: img.caption };
+  ```
+  > 이유: 신규 업로드 이미지의 캡션은 임시 `WorkImage`(`img`)에 저장되는데, 병합이 `real`만 스프레드하고 `order`만 승계해 **저장 시 캡션이 사라진다**. 기존 이미지 캡션 수정은 `:289 return img`로 보존되어 영향 없음 — 오직 "이번 세션에 새로 올린 이미지"만 해당.
+
+### Phase 4 — Admin 유효성 검사
+- [ ] `admin/src/data/api/worksApi.ts`: 각 이미지 `caption` 길이 검증 (`imageCaptionMaxLength` 초과 시 `ValidationError`)
+
+### Phase 5 — Front 표시 (두 곳 모두)
+- [x] ① `front/app/works/WorkDetailPage.tsx:511-545` 인라인 렌더 — **메인 상세 화면** (`ZoomableImage` 블록 아래에 `item.data.caption` 출력)
+- [x] ② `front/src/presentation/components/work/ModalImage.tsx` — 보조/연관작품 모달 (`ZoomableImage` 블록 아래에 `image.caption` 출력)
+  - 두 곳 모두 caption이 truthy일 때만 렌더 (R5)
+  - 스타일 (R2, R3):
+    ```css
+    font-size: var(--font-size-xs);   /* 이메일 텍스트와 동일 */
+    color: var(--color-gray-700);     /* 기존 캡션과 동일 */
+    line-height: var(--line-height-normal);
+    margin-top: var(--space-2);
+    text-align: right;                /* 이미지 아래 우측 정렬 (클라이언트 확정) */
+    ```
+  - plain text이므로 React 기본 이스케이프 사용. `dangerouslySetInnerHTML` 금지.
+
+> ⚠️ **메인 상세는 `ModalImage`가 아니라 `WorkDetailPage` 인라인 렌더**다(섹션 3 참고). 둘 다 수정하지 않으면 메인 진입 화면에 캡션이 안 보인다 — 실제로 겪은 버그.
+> ℹ️ 메인 인라인 렌더는 `isMobile` 분기가 없어 PC·모바일 공용. `ModalImage`도 WorkModal/WorkModalMobile 공유. → 모바일 별도 작업 불필요.
+
+### Phase 6 — 테스트
+- [ ] Mapper 통과 테스트: 이미지 `caption` 있음/없음 라운드트립 (필드 추가만으로 흐르는지 확인)
+- [ ] 🔴 **회귀 테스트(필수)**: 신규 업로드 이미지에 캡션 입력 → `uploadPendingFiles` 병합 후에도 caption 보존 (Phase 3 검증)
+- [ ] `ImageUploader` 테스트: 캡션 입력 시 `images` 상태/`onChange` 반영
+- [ ] `ModalImage` 테스트: 캡션 있으면 표시, 없으면 미표시
+- [ ] `worksApi` 검증 테스트: 길이 초과 시 `ValidationError`
+
+---
+
+## 7. 엣지 케이스 & 마이그레이션
+
+- **기존 데이터**: 기존 이미지엔 `caption` 없음 → optional이라 정상. DB 마이그레이션 불필요.
+- **빈 문자열 vs undefined**: 저장 직전 `removeUndefinedValues`(`WorkForm.tsx:387, :579`)가 정규화 → Firestore 직렬화 안전.
+- **이미지 순서 변경/삭제**: 캡션이 이미지 객체에 종속되어 자동으로 따라감 (설계 결정 2, 코드 검증됨).
+- **신규 업로드 이미지**: Phase 3 미적용 시 캡션 소실 — **반드시 같이 처리**.
+- **XSS**: plain text + React 이스케이프로 충분.
+- **긴 텍스트**: `imageCaptionMaxLength`로 입력 제한 + 표시 영역 줄바꿈/말줄임 정책 결정 필요.
+
+---
+
+## 8. 디자인 확정 사항
+
+1. **정렬**: 이미지 **아래 우측 정렬**(`text-align: right`)로 확정 (클라이언트 피드백). 오버레이/중앙 정렬 아님.
+2. **다중 줄**: "한 줄" 강조됨 → 단일 라인 `Input`으로 진행. 추후 필요 시 확장.
+
+---
+
+## 9. 작업 순서 요약
+
+```
+타입·상수(P1) → admin 입력 UI(P2) → 🔴 저장 병합 수정(P3) → admin 검증(P4) → front 표시(P5) → 테스트(P6)
+```
+
+- **Mapper 변경 없음**, **`PendingImage` 변경 없음** (둘 다 검증 완료).
+- **Front 표시는 두 곳**: ① `WorkDetailPage` 인라인(메인 상세) ② `ModalImage`(보조 모달). ①을 빠뜨리면 메인 진입 화면에 안 보임 — 실제로 겪은 버그.
+- **깨지기 쉬운 지점**: ⒜ `WorkForm.tsx:283` 병합(신규 업로드 캡션 소실) ⒝ Front 렌더 경로가 둘로 갈림.
+- front/admin `WorkImage` 타입이 분리돼 있으므로 **양쪽 모두** 필드 추가 필요.

--- a/front/app/works/WorkDetailPage.tsx
+++ b/front/app/works/WorkDetailPage.tsx
@@ -514,9 +514,15 @@ export default function WorkDetailPage({ workId }: WorkDetailPageProps) {
                             data-image-id={item.data.id}
                             className="work-image-container"
                             style={{
-                              marginBottom: isLast ? 0 : 'var(--space-8)',
+                              // 캡션은 absolute로 간격 안에 그리므로 간격이 늘지 않음.
+                              // 마지막 이미지만 캡션 공간을 살짝 확보.
+                              marginBottom: isLast
+                                ? (item.data.caption ? 'var(--space-6)' : 0)
+                                : 'var(--space-8)',
                               position: 'relative',
                               width: '100%',
+                              // inline-block 이미지 아래 descender 공백 제거 → 캡션이 이미지에 밀착
+                              lineHeight: 0,
                               scrollSnapAlign: 'start',
                               scrollMarginTop: '280px',
                             }}
@@ -541,6 +547,28 @@ export default function WorkDetailPage({ workId }: WorkDetailPageProps) {
                                 }}
                               />
                             </ZoomableImage>
+
+                            {/* 이미지 단위 캡션 — 기존 이미지 간격 안에 absolute로 표시(간격 유지), 빈 값이면 미출력 */}
+                            {item.data.caption && (
+                              <p
+                                style={{
+                                  position: 'absolute',
+                                  top: '100%',
+                                  right: 0,
+                                  marginTop: '13px',
+                                  marginBottom: 0,
+                                  maxWidth: '100%',
+                                  fontSize: 'var(--font-size-xs)',
+                                  color: 'var(--color-gray-700)',
+                                  lineHeight: 'var(--line-height-normal)',
+                                  textAlign: 'right',
+                                  whiteSpace: 'pre-wrap',
+                                  pointerEvents: 'none',
+                                }}
+                              >
+                                {item.data.caption}
+                              </p>
+                            )}
                           </div>
                         );
                       })}

--- a/front/app/works/WorkDetailPage.tsx
+++ b/front/app/works/WorkDetailPage.tsx
@@ -22,6 +22,7 @@ import {
   WorkModal,
   WorkModalMobile,
   CaptionWithBoundary,
+  ImageCaption,
   MediaTimeline,
   AnimatedCharacterText,
   ZoomableImage,
@@ -561,27 +562,8 @@ export default function WorkDetailPage({ workId }: WorkDetailPageProps) {
                               />
                             </ZoomableImage>
 
-                            {/* 이미지 단위 캡션 — 기존 이미지 간격 안에 absolute로 표시(간격 유지), 빈 값이면 미출력 */}
-                            {item.data.caption && (
-                              <p
-                                style={{
-                                  position: 'absolute',
-                                  top: '100%',
-                                  right: 0,
-                                  marginTop: '13px',
-                                  marginBottom: 0,
-                                  maxWidth: '100%',
-                                  fontSize: 'var(--font-size-xs)',
-                                  color: 'var(--color-gray-700)',
-                                  lineHeight: 'var(--line-height-normal)',
-                                  textAlign: 'right',
-                                  whiteSpace: 'pre-wrap',
-                                  pointerEvents: 'none',
-                                }}
-                              >
-                                {item.data.caption}
-                              </p>
-                            )}
+                            {/* 이미지 단위 캡션 (간격 유지·우측 하단, 빈 값이면 미출력) */}
+                            <ImageCaption caption={item.data.caption} />
                           </div>
                         );
                       })}

--- a/front/src/core/types/work.types.ts
+++ b/front/src/core/types/work.types.ts
@@ -11,6 +11,8 @@ export interface WorkImage {
   height: number;
   fileSize?: number;
   uploadedFrom?: 'desktop' | 'mobile' | 'camera';
+  /** 이미지 단위 캡션 (상세 화면에서 이미지 아래 한 줄로 표시, 선택값) */
+  caption?: string;
 }
 
 // 영상 (YouTube Embed)

--- a/front/src/data/__tests__/mappers/workMapper.test.ts
+++ b/front/src/data/__tests__/mappers/workMapper.test.ts
@@ -69,7 +69,7 @@ describe('workMapper', () => {
       const firestoreData = {
         title: 'Test Work',
         images: [
-          { id: 'img-1', url: 'a.jpg', thumbnailUrl: 'a-t.jpg', order: 0, width: 800, height: 600, caption: '사진_나혜빈' },
+          { id: 'img-1', url: 'a.jpg', thumbnailUrl: 'a-t.jpg', order: 0, width: 800, height: 600, caption: '사진_XXX' },
           { id: 'img-2', url: 'b.jpg', thumbnailUrl: 'b-t.jpg', order: 1, width: 800, height: 600 },
         ],
         createdAt: Timestamp.fromDate(new Date()),
@@ -78,7 +78,7 @@ describe('workMapper', () => {
 
       const result = mapFirestoreToWork('work-caption', firestoreData);
 
-      expect(result.images[0].caption).toBe('사진_나혜빈');
+      expect(result.images[0].caption).toBe('사진_XXX');
       expect(result.images[1].caption).toBeUndefined();
     });
 

--- a/front/src/data/__tests__/mappers/workMapper.test.ts
+++ b/front/src/data/__tests__/mappers/workMapper.test.ts
@@ -65,6 +65,23 @@ describe('workMapper', () => {
       expect(result.videos).toEqual([]);
     });
 
+    it('should preserve per-image caption through mapping', () => {
+      const firestoreData = {
+        title: 'Test Work',
+        images: [
+          { id: 'img-1', url: 'a.jpg', thumbnailUrl: 'a-t.jpg', order: 0, width: 800, height: 600, caption: '사진_나혜빈' },
+          { id: 'img-2', url: 'b.jpg', thumbnailUrl: 'b-t.jpg', order: 1, width: 800, height: 600 },
+        ],
+        createdAt: Timestamp.fromDate(new Date()),
+        updatedAt: Timestamp.fromDate(new Date()),
+      };
+
+      const result = mapFirestoreToWork('work-caption', firestoreData);
+
+      expect(result.images[0].caption).toBe('사진_나혜빈');
+      expect(result.images[1].caption).toBeUndefined();
+    });
+
     it('should handle empty or malformed data', () => {
       const id = 'work-3';
       const firestoreData = {};

--- a/front/src/presentation/__tests__/components/work/ModalImage.test.tsx
+++ b/front/src/presentation/__tests__/components/work/ModalImage.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ModalImage from '../../../components/work/ModalImage';
+import type { WorkImage } from '@/types';
+
+// 의존 컴포넌트는 패스스루로 모킹 (캡션 렌더 로직만 검증)
+vi.mock('@/presentation/ui', () => ({
+  // eslint-disable-next-line @next/next/no-img-element
+  FadeInImage: (props: { alt: string }) => <img alt={props.alt} />,
+}));
+vi.mock('@/presentation/components/media', () => ({
+  ZoomableImage: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const baseImage: WorkImage = {
+  id: 'img-1',
+  url: 'https://example.com/a.jpg',
+  thumbnailUrl: 'https://example.com/a-t.jpg',
+  order: 0,
+  width: 800,
+  height: 600,
+};
+
+describe('ModalImage 캡션 렌더', () => {
+  it('캡션이 있으면 텍스트를 표시한다', () => {
+    render(<ModalImage image={{ ...baseImage, caption: '사진_XXX' }} alt="작품" isLast={false} />);
+    expect(screen.getByText('사진_XXX')).toBeInTheDocument();
+  });
+
+  it('캡션이 없으면 캡션 문단을 렌더하지 않는다', () => {
+    const { container } = render(<ModalImage image={baseImage} alt="작품" isLast={false} />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('캡션이 빈 문자열이면 렌더하지 않는다', () => {
+    const { container } = render(<ModalImage image={{ ...baseImage, caption: '' }} alt="작품" isLast={false} />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+});

--- a/front/src/presentation/components/index.ts
+++ b/front/src/presentation/components/index.ts
@@ -18,4 +18,5 @@ export { default as FloatingWorkWindow } from './work/FloatingWorkWindow';
 export { default as WorkModal } from './work/WorkModal';
 export { default as WorkModalMobile } from './work/WorkModalMobile';
 export { default as CaptionWithBoundary } from './work/CaptionWithBoundary';
+export { default as ImageCaption } from './work/ImageCaption';
 export { default as MediaTimeline } from './work/MediaTimeline';

--- a/front/src/presentation/components/work/ImageCaption.tsx
+++ b/front/src/presentation/components/work/ImageCaption.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * 이미지 단위 캡션 스타일.
+ * - 컨테이너(position: relative) 기준 absolute로 기존 이미지 간격 안에 표시 → 간격이 늘지 않음
+ * - 이미지 아래 우측 정렬, 색/폰트는 기존 캡션·이메일 텍스트와 동일
+ *
+ * 메인 상세(WorkDetailPage 인라인 렌더)와 보조 모달(ModalImage)에서 공유한다.
+ * 단일 소스로 두어 두 렌더 경로의 스타일이 어긋나지 않게 한다.
+ */
+const CAPTION_STYLE: CSSProperties = {
+  position: 'absolute',
+  top: '100%',
+  right: 0,
+  marginTop: '13px',
+  marginBottom: 0,
+  maxWidth: '100%',
+  fontSize: 'var(--font-size-xs)',
+  color: 'var(--color-gray-700)',
+  lineHeight: 'var(--line-height-normal)',
+  textAlign: 'right',
+  whiteSpace: 'pre-wrap',
+  pointerEvents: 'none',
+};
+
+interface ImageCaptionProps {
+  /** 이미지 단위 캡션 텍스트 (선택값) */
+  caption?: string;
+}
+
+/** 이미지 단위 캡션 — 빈 값이면 미출력. 상위 컨테이너는 position: relative 여야 한다. */
+export default function ImageCaption({ caption }: ImageCaptionProps) {
+  if (!caption) return null;
+  return <p style={CAPTION_STYLE}>{caption}</p>;
+}

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -25,9 +25,12 @@ export default function ModalImage({ image, alt, isLast, marginBottom = 'var(--s
     <div
       data-image-id={image.id}
       style={{
-        marginBottom: isLast ? 0 : marginBottom,
+        // 캡션은 absolute로 간격 안에 그리므로 간격이 늘지 않음. 마지막 이미지만 캡션 공간 확보.
+        marginBottom: isLast ? (image.caption ? 'var(--space-6)' : 0) : marginBottom,
         position: 'relative',
         width: '100%',
+        // inline-block 이미지 아래 descender 공백 제거 → 캡션이 이미지에 밀착
+        lineHeight: 0,
       }}
     >
       <ZoomableImage
@@ -50,6 +53,28 @@ export default function ModalImage({ image, alt, isLast, marginBottom = 'var(--s
           }}
         />
       </ZoomableImage>
+
+      {/* 이미지 단위 캡션 — 기존 이미지 간격 안에 absolute로 표시(간격 유지), 빈 값이면 미출력 */}
+      {image.caption && (
+        <p
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            marginTop: '13px',
+            marginBottom: 0,
+            maxWidth: '100%',
+            fontSize: 'var(--font-size-xs)',
+            color: 'var(--color-gray-700)',
+            lineHeight: 'var(--line-height-normal)',
+            textAlign: 'right',
+            whiteSpace: 'pre-wrap',
+            pointerEvents: 'none',
+          }}
+        >
+          {image.caption}
+        </p>
+      )}
     </div>
   );
 }

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -7,6 +7,7 @@
 
 import { FadeInImage } from '@/presentation/ui';
 import { ZoomableImage } from '@/presentation/components/media';
+import ImageCaption from './ImageCaption';
 import type { WorkImage } from '@/types';
 
 interface ModalImageProps {
@@ -78,27 +79,8 @@ export default function ModalImage({
         />
       </ZoomableImage>
 
-      {/* 이미지 단위 캡션 — 기존 이미지 간격 안에 absolute로 표시(간격 유지), 빈 값이면 미출력 */}
-      {image.caption && (
-        <p
-          style={{
-            position: 'absolute',
-            top: '100%',
-            right: 0,
-            marginTop: '13px',
-            marginBottom: 0,
-            maxWidth: '100%',
-            fontSize: 'var(--font-size-xs)',
-            color: 'var(--color-gray-700)',
-            lineHeight: 'var(--line-height-normal)',
-            textAlign: 'right',
-            whiteSpace: 'pre-wrap',
-            pointerEvents: 'none',
-          }}
-        >
-          {image.caption}
-        </p>
-      )}
+      {/* 이미지 단위 캡션 (간격 유지·우측 하단, 빈 값이면 미출력) */}
+      <ImageCaption caption={image.caption} />
     </div>
   );
 }

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // tsconfig의 `@/*` → `./*`(루트 기준) 매핑과 일치시켜 `@/src/...` import를 해석
+      // (예: `@/src/data` → front/src/data). 더 구체적인 `@/src`를 catch-all `@`보다 먼저 둔다.
+      '@/src': path.resolve(__dirname, './src'),
       '@': path.resolve(__dirname, './src'),
       '@/core': path.resolve(__dirname, './src/core'),
       '@/data': path.resolve(__dirname, './src/data'),

--- a/tasks/IMAGE_CAPTION_PLAN.md
+++ b/tasks/IMAGE_CAPTION_PLAN.md
@@ -167,11 +167,13 @@
 > ℹ️ 메인 인라인 렌더는 `isMobile` 분기가 없어 PC·모바일 공용. `ModalImage`도 WorkModal/WorkModalMobile 공유. → 모바일 별도 작업 불필요.
 
 ### Phase 6 — 테스트
-- [ ] Mapper 통과 테스트: 이미지 `caption` 있음/없음 라운드트립 (필드 추가만으로 흐르는지 확인)
-- [ ] 🔴 **회귀 테스트(필수)**: 신규 업로드 이미지에 캡션 입력 → `uploadPendingFiles` 병합 후에도 caption 보존 (Phase 3 검증)
-- [ ] `ImageUploader` 테스트: 캡션 입력 시 `images` 상태/`onChange` 반영
-- [ ] `ModalImage` 테스트: 캡션 있으면 표시, 없으면 미표시
-- [ ] `worksApi` 검증 테스트: 길이 초과 시 `ValidationError`
+- [x] Mapper 통과 테스트: 이미지 `caption` 라운드트립 (front/admin `workMapper.test.ts`, 각 9개)
+- [x] 🔴 **회귀 테스트(필수)**: 병합 로직을 순수 함수 `mergeUploadedImages`로 추출 후 caption 보존 검증 (`imageUploadMerge.test.ts`, 5개)
+- [x] `ImageUploader` 테스트: 모달 캡션 입력/취소/미리보기 (`ImageUploader.caption.test.tsx`, 4개)
+- [x] `ModalImage` 테스트: 캡션 있으면 표시, 없으면/빈 값이면 미표시 (`ModalImage.test.tsx`, 3개)
+- [x] `worksApi` 검증 테스트: 200자 초과 시 `ValidationError(IMAGE_CAPTION_TOO_LONG)` (`worksApi.imageCaption.test.ts`, 4개)
+
+> Phase 6 완료. `uploadPendingFiles`의 병합 로직은 컴포넌트 클로저라 단위 테스트가 어려워, 순수 함수 `core/utils/imageUploadMerge.ts`로 추출하고 `WorkForm`이 이를 사용하도록 리팩터하여 회귀 테스트를 추가함.
 
 ---
 

--- a/tasks/IMAGE_CAPTION_PLAN.md
+++ b/tasks/IMAGE_CAPTION_PLAN.md
@@ -2,14 +2,14 @@
 
 > 작성일: 2026-06-22 (코드 검증 후 갱신)
 > 브랜치: `feature-image-caption`
-> 스펙 출처: 클라이언트(나혜빈) 요청 — `KakaoTalk_Photo_2026-06-22-22-20-53.jpeg`
+> 스펙 출처: 클라이언트(XXX) 요청 — `KakaoTalk_Photo_2026-06-22-22-20-53.jpeg`
 
 ---
 
 ## 1. 목표 (Goal)
 
 **카테고리(키워드)를 클릭해 진입하는 작품 상세 화면**에서, 세로로 나열되는 **각 이미지 아래에 한 줄짜리 캡션 텍스트**를 표시할 수 있게 한다.
-예: `사진_나혜빈` 같은 사진 출처/설명 문구.
+예: `사진_XXX` 같은 사진 출처/설명 문구.
 
 ### 스펙 원문 요약
 
@@ -132,7 +132,7 @@
 
 ### Phase 2 — Admin 입력 UI
 - [ ] `admin/src/components/ImageUploader.tsx`: 각 이미지 카드(`:323` 액션 영역 부근)에 단일 라인 `Input` 추가
-  - placeholder 예: `"사진 캡션 (선택, 예: 사진_나혜빈)"`, `maxLength={200}`
+  - placeholder 예: `"사진 캡션 (선택, 예: 사진_XXX)"`, `maxLength={200}`
   - `onChange` → 해당 `images[index]`의 `caption` 갱신 후 `onChange(newImages)` 호출 (PendingImage 경로 아님)
 - [ ] `admin/src/pages/WorkForm.tsx`: 변경 감지(`hasChanges`, `:111-138`)에 이미지 캡션 변경 반영
 


### PR DESCRIPTION
## 개요
작품 상세 화면의 각 이미지 아래에 한 줄 캡션(예: `사진_나혜빈`)을 표시하는 기능을 추가합니다. 클라이언트(나혜빈) 요청 스펙 기반.

기존 `Work.caption`(작품 단위 리치텍스트)과는 별개로, **이미지마다 개별**로 입력하는 선택값입니다.

## 변경 사항

### 데이터 / 타입
- `WorkImage`에 `caption?: string` 추가 (front/admin 양쪽)
- `imageCaptionMaxLength = 200` 상수 추가
- Mapper 변경 없음 — 이미지 배열이 통째로 통과되어 caption 자동 흐름

### admin
- `ImageUploader`: 이미지 카드마다 캡션 미리보기 + **모달 편집 UI**(넓은 TextArea, 글자수/200자 제한)
- `WorkForm`: 업로드 병합 시 신규 이미지 캡션 보존 (소실 버그 수정)
- `worksApi`: 이미지 캡션 길이 검증

### front
- 상세 화면(`WorkDetailPage` 인라인) + 보조 모달(`ModalImage`) **두 경로 모두**에 캡션 표시
- 이미지 아래 **우측 정렬**, 색 `--color-gray-700`, 폰트 `--font-size-xs`
- 기존 이미지 간격 유지(absolute 배치) + 이미지에 13px 밀착, 빈 값이면 미출력

### 테스트 / 문서
- 매퍼 캡션 라운드트립 테스트 (front/admin)
- 구현 계획 문서 `docs/plans/IMAGE_CAPTION_PLAN.md`

## 검증
- 타입 체크 / ESLint 클린
- 관련 테스트 통과 (workMapper, WorkModal)
- 헤드리스 브라우저로 캡션 렌더·간격(이미지간 64px 유지, 이미지-캡션 13px) 확인
- 최신 `main`(이미지 로딩 최적화) 머지 후 충돌 없이 통합 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)