### PR TITLE
perf(lcp): CSR waterfall 1차 — 렌더 직렬화 제거(A) + 카테고리 서버 SSR 하이드레이션(B 부분)

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { queryKeys, CategoryRepository, WorkRepository } from '@/src/data';
 import { ErrorBoundary, PortfolioLayoutSimple, DebugGrid, ColorPaletteDebugger } from '@/presentation';
 import ImageZoomProvider from '@/presentation/components/layout/ImageZoomProvider';
 import { AnalyticsProvider } from '@/presentation/components/analytics/AnalyticsProvider';
@@ -13,6 +15,42 @@ import {
 } from '@/state';
 import React, { Suspense } from "react";
 import { LoadingContainer } from '@/presentation/ui';
+
+// 매 요청마다 서버에서 최신 데이터를 읽어 SSR(새 업로드 즉시 반영 보장).
+export const dynamic = 'force-dynamic';
+
+/** 서버 사전 페칭 상한(ms). 초과 시 부분 결과로 진행하고 클라이언트가 나머지를 페칭. */
+const SSR_PREFETCH_TIMEOUT_MS = 2000;
+
+/**
+ * 레이아웃에 항상 필요한 전역 데이터(카테고리 네비 + 작품 목록)를 서버에서 미리 읽어
+ * dehydrate한다. 카테고리 네비는 layout에서 렌더되므로 여기서 하이드레이션해야
+ * 초기 HTML에 콘텐츠가 담겨 JS+Firestore 왕복 없이 즉시 표시된다(CSR waterfall 단축).
+ * searchParams와 무관한 전역 데이터라 클라이언트 탐색 시 서버 왕복을 유발하지 않는다.
+ * 서버 페칭이 지연/실패해도 SSR을 막지 않도록 타임아웃을 두고, 미완료분은 클라이언트가 페칭.
+ */
+async function prefetchGlobalData() {
+  const queryClient = new QueryClient();
+  const prefetch = Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.categories.sentence.all(),
+      queryFn: () => CategoryRepository.getSentenceCategories(),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.categories.exhibition.all(),
+      queryFn: () => CategoryRepository.getExhibitionCategories(),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.works.published(),
+      queryFn: () => WorkRepository.getPublishedWorks(),
+    }),
+  ]);
+  await Promise.race([
+    prefetch,
+    new Promise((resolve) => setTimeout(resolve, SSR_PREFETCH_TIMEOUT_MS)),
+  ]);
+  return dehydrate(queryClient);
+}
 
 // 나눔명조(OFL)를 KS X 1001 상용 한글 2,350자 + ASCII로 직접 서브셋해 self-host.
 // next/font/google가 한글 unicode-range 청크 100여 개(=1.66MB)를 온디맨드로 받던 것을
@@ -46,11 +84,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const dehydratedState = await prefetchGlobalData();
   return (
     <html lang="ko">
       <head>
@@ -68,6 +107,7 @@ export default function RootLayout({
         <ErrorBoundary>
           <ToastProvider>
             <QueryProvider>
+              <HydrationBoundary state={dehydratedState}>
               <AnalyticsProvider>
               <CategoriesProvider>
                 <CategorySelectionProvider>
@@ -83,6 +123,7 @@ export default function RootLayout({
                 </CategorySelectionProvider>
               </CategoriesProvider>
             </AnalyticsProvider>
+              </HydrationBoundary>
           </QueryProvider>
           </ToastProvider>
         </ErrorBoundary>

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import { queryKeys, CategoryRepository, WorkRepository } from '@/src/data';
+import { queryKeys, CategoryRepository } from '@/src/data';
 import { ErrorBoundary, PortfolioLayoutSimple, DebugGrid, ColorPaletteDebugger } from '@/presentation';
 import ImageZoomProvider from '@/presentation/components/layout/ImageZoomProvider';
 import { AnalyticsProvider } from '@/presentation/components/analytics/AnalyticsProvider';
@@ -23,11 +23,12 @@ export const dynamic = 'force-dynamic';
 const SSR_PREFETCH_TIMEOUT_MS = 2000;
 
 /**
- * 레이아웃에 항상 필요한 전역 데이터(카테고리 네비 + 작품 목록)를 서버에서 미리 읽어
- * dehydrate한다. 카테고리 네비는 layout에서 렌더되므로 여기서 하이드레이션해야
- * 초기 HTML에 콘텐츠가 담겨 JS+Firestore 왕복 없이 즉시 표시된다(CSR waterfall 단축).
+ * 레이아웃에 항상 필요한 전역 데이터(카테고리 네비)를 서버에서 미리 읽어 dehydrate한다.
+ * 카테고리 네비는 layout에서 렌더되므로 여기서 하이드레이션해야 초기 HTML에 담겨
+ * JS+Firestore 왕복 없이 즉시 표시된다(CSR waterfall 단축).
  * searchParams와 무관한 전역 데이터라 클라이언트 탐색 시 서버 왕복을 유발하지 않는다.
  * 서버 페칭이 지연/실패해도 SSR을 막지 않도록 타임아웃을 두고, 미완료분은 클라이언트가 페칭.
+ * (작품 목록은 카테고리별/searchParams 의존이라 layout이 아닌 page에서 별도 처리.)
  */
 async function prefetchGlobalData() {
   const queryClient = new QueryClient();
@@ -39,10 +40,6 @@ async function prefetchGlobalData() {
     queryClient.prefetchQuery({
       queryKey: queryKeys.categories.exhibition.all(),
       queryFn: () => CategoryRepository.getExhibitionCategories(),
-    }),
-    queryClient.prefetchQuery({
-      queryKey: queryKeys.works.published(),
-      queryFn: () => WorkRepository.getPublishedWorks(),
     }),
   ]);
   await Promise.race([

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -24,7 +24,11 @@ function HomePageContent(): ReactElement {
   const searchParams = useSearchParams();
   const workId = searchParams.get('workId');
 
-  if (isLoading) {
+  // workId가 있으면 카테고리 로딩을 기다리지 않고 즉시 상세를 렌더한다.
+  // 카테고리는 레이아웃 네비용일 뿐 상세 본문/LCP 이미지와 독립적이므로,
+  // 이 게이트를 두면 상세 LCP 이미지 로딩이 카테고리 왕복 뒤로 직렬화된다.
+  // workId가 없을 때(홈)만 카테고리 로딩 스피너를 표시한다.
+  if (!workId && isLoading) {
     return <LoadingContainer size={24} />;
   }
 

--- a/front/src/presentation/ui/media/FadeInImage.tsx
+++ b/front/src/presentation/ui/media/FadeInImage.tsx
@@ -66,8 +66,8 @@ export default function FadeInImage({
         overflow: 'hidden',
       }}
     >
-      {/* 스켈레톤 - 일정 시간 후에도 로딩 중일 때만 표시 (LCP priority 이미지는 제외) */}
-      {!priority && !isLoaded && showSkeleton && (
+      {/* 스켈레톤 - 일정 시간 후에도 로딩 중일 때만 표시 */}
+      {!isLoaded && showSkeleton && (
         <div
           className="skeleton-shimmer"
           style={{

--- a/front/src/presentation/ui/media/FadeInImage.tsx
+++ b/front/src/presentation/ui/media/FadeInImage.tsx
@@ -66,8 +66,8 @@ export default function FadeInImage({
         overflow: 'hidden',
       }}
     >
-      {/* 스켈레톤 - 일정 시간 후에도 로딩 중일 때만 표시 */}
-      {!isLoaded && showSkeleton && (
+      {/* 스켈레톤 - 일정 시간 후에도 로딩 중일 때만 표시 (LCP priority 이미지는 제외) */}
+      {!priority && !isLoaded && showSkeleton && (
         <div
           className="skeleton-shimmer"
           style={{
@@ -98,8 +98,10 @@ export default function FadeInImage({
           width: '100%',
           height: '100%',
           objectFit: 'cover',
-          opacity: isLoaded ? 1 : 0,
-          transition: 'opacity 0.3s ease-in-out',
+          // LCP(priority) 이미지는 페이드 게이트 없이 즉시 표시해 paint 지연을 없앤다.
+          // 그 외 이미지는 기존 fade-in 유지.
+          opacity: priority || isLoaded ? 1 : 0,
+          transition: priority ? undefined : 'opacity 0.3s ease-in-out',
         }}
       />
     </div>


### PR DESCRIPTION
PR #54 계획(`tasks/next-csr-waterfall-plan.md`)의 **CSR waterfall 개선 1차**. 남은 LCP 병목인 "렌더 시작까지의 대기"를 저위험 범위에서 단축한다.

## 변경

### Tier A — 렌더 직렬화 / 페이드 게이트 제거
- **`app/page.tsx`**: `workId`가 있으면 `useCategories().isLoading` 스피너로 막지 않고 즉시 상세 렌더(카테고리 왕복 뒤로 직렬화되던 것 제거).
- **`FadeInImage`**: `priority`(LCP) 이미지는 opacity 0→1 **페이드 게이트만 제거**(즉시 표시). 스켈레톤은 모든 이미지에 동일 유지.

### Tier B(부분) — 카테고리 서버 SSR 하이드레이션
- **`app/layout.tsx`**: 카테고리(sentence/exhibition)를 **서버에서 prefetch → dehydrate → HydrationBoundary** 주입. 카테고리 네비가 layout에서 렌더되므로 하이드레이션도 layout에서 수행 → 초기 HTML에 담겨 즉시 표시.
- 효과: `useCategories().isLoading`이 첫 렌더에 이미 false → **홈의 카테고리 스피너 제거 + 네비 SSR 렌더**.
- `export const dynamic = 'force-dynamic'`: 매 요청 최신 데이터 → **새 업로드 즉시 반영 유지**.
- 안전장치: 서버 페칭 2초 타임아웃 + `prefetchQuery` 에러 무시 → 실패해도 SSR 안 멈추고 **클라이언트 폴백**. 탐색 시 서버 왕복 없음(전역 데이터).

## 검증

- ✅ `npm run build` 통과, 라우트 `ƒ (Dynamic)` 전환, lint 0 error.
- ✅ Firebase 웹 SDK가 Node에서 `getDocs` 동작(150ms), 카테고리 dehydrate 정상(sentence 4 + exhibition 3건, 5.9KB).
- ✅ 서버 페칭 실패 시 graceful fallback(로컬 200/62ms).
- 🐛 초기 커밋에 있던 `works.published()` 사전 페칭은 **앱 미사용 + 복합 인덱스 없음으로 실패하는 죽은 쿼리**여서 제거(커밋 `a0c2672`).

## 보류 (다음 단계)

- **작품 목록(썸네일) SSR**: 작품 목록은 layout의 `PortfolioLayoutSimple`에서 client 선택 상태(URL→effect 동기화)에 묶여 렌더되므로, SSR하려면 선택 로직 리팩터링 필요(네비 회귀 위험 + 로컬 검증 불가). 본 PR 배포·측정 결과를 보고 별도 결정.

## 배포 후 측정

- 동일 상세 URL + 홈으로 Lighthouse 재측정 → LCP/FCP 변화 확인(현재 baseline: 상세 LCP 7.5s, 홈 LCP 12.5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
