### PR TITLE
feat: 모달 안에서는 이미지 단위 캡션 숨김

### DIFF
--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -7,7 +7,6 @@
 
 import { FadeInImage } from '@/presentation/ui';
 import { ZoomableImage } from '@/presentation/components/media';
-import ImageCaption from './ImageCaption';
 import type { WorkImage } from '@/types';
 
 interface ModalImageProps {
@@ -47,11 +46,11 @@ export default function ModalImage({
     <div
       data-image-id={image.id}
       style={{
-        // 캡션은 absolute로 간격 안에 그리므로 간격이 늘지 않음. 마지막 이미지만 캡션 공간 확보.
-        marginBottom: isLast ? (image.caption ? 'var(--space-6)' : 0) : marginBottom,
+        // 모달에서는 이미지 단위 캡션을 표시하지 않으므로 마지막 이미지 하단 여백 불필요.
+        marginBottom: isLast ? 0 : marginBottom,
         position: 'relative',
         width: '100%',
-        // inline-block 이미지 아래 descender 공백 제거 → 캡션이 이미지에 밀착
+        // inline-block 이미지 아래 descender 공백 제거
         lineHeight: 0,
       }}
     >
@@ -78,9 +77,6 @@ export default function ModalImage({
           }}
         />
       </ZoomableImage>
-
-      {/* 이미지 단위 캡션 (간격 유지·우측 하단, 빈 값이면 미출력) */}
-      <ImageCaption caption={image.caption} />
     </div>
   );
 }


### PR DESCRIPTION
## 배경
PR #52에서 추가된 **이미지 단위 캡션**(`ImageCaption`)이 두 렌더 경로 모두에 적용돼 있었음:
- 상세 페이지 인라인 (`WorkDetailPage`)
- 모달 (`ModalImage` → `WorkModal`/`WorkModalMobile`)

요청에 따라 **모달 안에서는 개별 캡션을 표시하지 않도록** 변경한다.

## 변경 (`ModalImage.tsx`)
- `<ImageCaption caption={image.caption} />` 렌더 제거 + 미사용 `ImageCaption` import 제거.
- 캡션이 없어지므로, 마지막 이미지 하단에 캡션용으로 예약하던 여백 로직 제거(`isLast ? 0`).

## 영향 범위
- **모달(데스크톱/모바일)**: 이미지 개별 캡션 미표시 ✅
- **상세 페이지 인라인**: 캡션 그대로 유지(변경 없음).
- 줌/이미지 표시/품질 등 다른 동작 무변경.

## 검증
- `npm run build` 통과, 변경 파일 lint 0 error(미사용 import/변수 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)