### PR TITLE
docs(perf): 첫 이미지 로딩 개선 4안 계획서 + 벤치마크

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ firebase-export-*/
 # Firebase Service Account Keys (CRITICAL: Never commit!)
 *serviceAccountKey*.json
 oval-replica-*.json
+
+# Lighthouse benchmark artifacts (local only)
+lh-*.report.*
+lh-mobile.html
+docs/plans/**/lh-runs/

--- a/docs/plans/first-image-loading/01-data-prefetch.md
+++ b/docs/plans/first-image-loading/01-data-prefetch.md
@@ -1,0 +1,58 @@
+# 계획서 ①: 데이터 prefetch 보강
+
+> 상태: **초안 (구현 보류)**
+> 난이도: 낮음 · 디자인 변화: 없음 · Storage 비용: ~0
+
+## 1. 목표
+
+상세 진입 **직전**에 작품 메타데이터(이미지 URL 포함)를 React Query 캐시에 미리 채워, 클릭 순간 `useWork`가 캐시 히트하도록 한다. 워터폴의 "하이드레이션 → 쿼리 → Firestore getDoc" 구간을 클릭 전으로 옮긴다.
+
+- 이미지 바이트는 아직 안 받으므로 다운로드 시간 자체는 그대로. **"URL 알아내는 지연"만 제거** (수백 ms 절약).
+- 비용: Firestore read 1회. Storage egress 무관.
+
+## 2. 현재 상태
+
+- `usePrefetchWork` 훅 존재: `front/src/domain/hooks/useWorks.ts:47-61`.
+- **구현된 곳**: 홈의 `WorkTitleButton` 호버(`onMouseEnter`) → `prefetchWork(work.id)` (`WorkTitleButton.tsx:127-130`).
+- **누락된 곳**:
+  - 상세 화면 **캡션 링크 호버** → `FloatingWorkWindow`가 뜨지만 prefetch 미실행 (`useCaptionHoverEvents.ts`).
+  - **모바일**: 호버가 없어 prefetch가 전혀 안 걸림. 터치로 바로 진입.
+
+## 3. 변경 내용
+
+### (a) 캡션 링크 호버 prefetch
+- `useCaptionHoverEvents`의 `handleLinkMouseEnter`에서 `linkWorkId` 확정 시 `prefetchWork(linkWorkId)` 호출.
+- 이미 `FloatingWorkWindow` 표시용 hoverDelay 타이머가 있으므로, 같은 인텐트 시점에 prefetch를 끼운다.
+- 파일: `front/src/domain/hooks/useCaptionHoverEvents.ts`.
+
+### (b) 모바일 인텐트 prefetch
+- 호버가 없는 모바일은 `onTouchStart`(또는 `onPointerDown`)에서 `prefetchWork(work.id)` 호출.
+- 탭 직전 prefetch라 클릭→렌더 사이 짧은 시간이라도 데이터 leg를 당김.
+- 파일: `front/src/presentation/components/work/WorkTitleButton.tsx` (`onMouseEnter`와 별도로 `onTouchStart` 추가).
+
+### (c) 호버 디바운스(선택, 비용 관점)
+- 데이터 prefetch는 비용이 거의 0이라 디바운스 필수는 아님. 다만 과도한 Firestore read를 피하려면 호버 100~150ms 유지 시에만 발사하도록 통일 가능.
+- `usePrefetchWork`는 React Query가 staleTime 내 중복 호출을 자동 dedupe하므로 안전.
+
+## 4. 리스크 / 주의
+
+- React Query `prefetchQuery`는 동일 키 중복 시 dedupe되고 staleTime(10분) 내 재요청 없음 → 과호출 위험 낮음.
+- 모바일 `onTouchStart`는 스크롤 제스처에서도 발화할 수 있음 → 비용이 거의 0이라 허용 가능하나, 신경 쓰이면 `onPointerDown` + 짧은 이동 임계로 제한.
+- 캡션 링크 prefetch는 `FloatingWorkWindow` 로직과 타이머를 공유하므로 중복 타이머 생성 주의.
+
+## 5. 검증 — 측정 가능한 벤치마크
+
+> 합격 기준 전문: [BENCHMARKS.md §4 ①](./BENCHMARKS.md#4-plan별-합격-기준-pass-gate)
+
+**Pass gate (5회 중앙값):**
+- 진입 인텐트(호버/터치) 후 클릭 시 Firestore getDoc **추가 요청 0건**(캐시 히트).
+- 클릭→첫 이미지 요청 시작 지연(Load Delay 상당) **≥ 30% 단축** (캡션 링크·모바일 경로).
+- Storage egress 증가 없음(Firestore read만), 기존 동작 회귀 없음.
+
+**측정 절차:**
+- DevTools 네트워크 탭으로 호버/터치 시점 Firestore 요청 선발생 + 클릭 후 추가 요청 0 확인.
+- 클라이언트 네비게이션은 Lighthouse로 안 잡히므로, Performance 패널 트레이스로 클릭→이미지 요청 구간을 before/after 비교.
+
+## 6. 롤백
+
+- 추가한 prefetch 호출만 제거하면 즉시 원복. 데이터/타입 변경 없음.

--- a/docs/plans/first-image-loading/02-ssr-preload.md
+++ b/docs/plans/first-image-loading/02-ssr-preload.md
@@ -1,0 +1,89 @@
+# 계획서 ②: SSR / 이미지 preload
+
+> 상태: **초안 (구현 보류)**
+> 난이도: 높음 · 디자인 변화: 없음 · Storage 비용: 0
+
+## 1. 목표
+
+URL에 `workId`가 있는 첫 진입(직접 링크/새로고침/공유)에서, **서버가 첫 이미지 URL을 미리 알아내** HTML `<head>`에 `<link rel="preload" as="image">`를 주입한다. 브라우저가 JS 하이드레이션을 기다리지 않고 **첫 이미지를 즉시 다운로드 시작**.
+
+- 워터폴의 "JS 번들 → 하이드레이션 → useWork 쿼리 → Firestore getDoc" 구간을 **첫 이미지에 한해 통째로 제거**.
+- 디자인·비용 변화 없음. 현재 스켈레톤·fade 그대로, 실이미지 도착만 앞당김.
+
+> 적용 범위는 **첫 진입(SSR이 의미 있는 시점)**. SPA 내부 클라이언트 네비게이션(목록 클릭)은 prefetch(①③)가 담당.
+
+## 2. 제약 (조사 결과)
+
+- `firebase-admin` 없음. 현재 데이터는 **클라이언트 firebase SDK**(`getDoc`)로만 읽음 — 서버에서 그대로 호출 불가.
+- 상세는 별도 라우트가 아니라 `app/page.tsx`(현재 `'use client'`)에서 `useSearchParams()`로 `workId`를 읽어 조건부 렌더.
+- 따라서 두 가지를 풀어야 한다: **(A) 서버에서 첫 이미지 URL 확보** + **(B) 서버 렌더 경계에서 preload 링크 주입**.
+
+## 3. (A) 서버에서 첫 이미지 URL 확보 — 옵션
+
+| 옵션 | 방법 | 장점 | 단점 |
+|------|------|------|------|
+| **A1. Firestore REST API** ✅ 추천 | 서버에서 `https://firestore.googleapis.com/v1/projects/{pid}/databases/(default)/documents/works/{id}` GET | `firebase-admin` 불필요, 가장 가벼움, fetch 한 번 | 공개 읽기 보안 규칙 전제, 응답 매핑 별도 |
+| A2. firebase-admin 도입 | 서버 SDK로 인증된 읽기 | 정석, 비공개 데이터도 가능 | 의존성·서비스계정 키 관리, 콜드스타트 무게 |
+| A3. 클라이언트 SDK를 서버에서 호출 | RSC에서 firebase JS SDK `getDoc` | 코드 재사용 | Node 환경 지원 불안정, 권장도 낮음 |
+
+- **추천: A1**. 이 사이트는 공개 포트폴리오라 `isPublished` 문서는 공개 읽기일 가능성이 높음 → **보안 규칙 확인 필요(확정 항목)**.
+- 서버에서 필요한 건 **첫 이미지 1장의 url·width·height뿐**. 전체 문서를 받되 매핑은 최소화.
+- 서버 결과는 클라이언트 React Query 캐시에 dehydrate로 전달하면 ①과 시너지(하이드레이션 직후 추가 fetch 불필요).
+
+## 4. (B) preload 링크 주입
+
+- `app/page.tsx`를 **서버 컴포넌트로 분리**: 서버 컴포넌트가 `searchParams.workId`를 받아(서버에서 사용 가능) preload 링크를 렌더하고, 인터랙티브 UI는 클라이언트 자식으로 내림.
+  - 현재 page가 `useSearchParams` 기반 클라이언트라 **경계 리팩토링**이 핵심 작업.
+  - 대안: Next `generateMetadata` 또는 서버 컴포넌트에서 `<link>`를 직접 렌더.
+- preload URL은 **next/image가 실제 요청할 변형 URL과 일치**해야 캐시 적중:
+  ```html
+  <link
+    rel="preload"
+    as="image"
+    imagesrcset="/_next/image?url=<enc>&w=640&q=72 640w, .../w=1080&q=72 1080w, ..."
+    imagesizes="(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw"
+    fetchpriority="high"
+  />
+  ```
+  - `q`는 `DETAIL_IMAGE_QUALITY(72)`, `imagesizes`는 `DETAIL_IMAGE_SIZES`와 동일하게.
+  - `deviceSizes`(384/640/750/828/1080/1200/1920)에 맞춰 srcset 구성 → 브라우저가 뷰포트에 맞는 변형만 받음.
+- 모바일/데스크톱 모두 동일 링크로 커버(imagesizes가 분기 처리).
+
+## 5. 단계
+
+1. 보안 규칙 확인: `works` 공개 읽기 가능 여부 → A1 가능성 확정.
+2. 서버 유틸 `getFirstImageForPreload(workId)` 작성 (A1, REST fetch + 최소 매핑).
+3. `app/page.tsx` 서버/클라이언트 경계 분리, `searchParams` 서버 수신.
+4. 서버 컴포넌트에서 preload `<link>` 렌더(첫 이미지 변형 URL 구성 유틸 포함).
+5. (선택) 서버에서 읽은 상세를 React Query dehydrate로 전달.
+6. Lighthouse로 첫 진입 LCP 비교.
+
+## 6. 리스크 / 주의
+
+- **변형 URL 불일치 시 이중 다운로드**: preload한 URL과 next/image 실제 요청이 다르면 낭비. `w/q/sizes`를 한 곳에서 상수로 공유해 일치 보장.
+- **경계 리팩토링 범위**: page가 클라이언트 상태(useSearchParams, 모달 등)에 깊게 얽혀 있어 분리 난이도 있음. 최소 침습으로 preload 링크만 서버에서 추가하는 방향 우선.
+- **보안 규칙**: A1이 막히면 A2(firebase-admin)로 승격 필요 — 의존성·키 관리 작업 추가.
+- force-dynamic 유지: 매 요청 서버 fetch 1회 추가(첫 이미지 메타). 가벼운 단일 문서라 부담 낮음.
+
+## 7. 검증 — 측정 가능한 벤치마크
+
+> 합격 기준 전문: [BENCHMARKS.md §4 ②](./BENCHMARKS.md#4-plan별-합격-기준-pass-gate)
+
+**Pass gate (cold, 5회 중앙값):**
+- **LCP·Load Delay: 4,332ms → ≤ 1,500ms** (CSR 워터폴 제거 → TTFB+α 수준).
+- **LCP 총합: baseline 대비 ≥ 25% 단축**.
+- preload URL과 next/image 실제 요청 URL **일치**(중복 변형 다운로드 0).
+
+**측정 절차:**
+```bash
+cd docs/plans/first-image-loading
+./measure-lcp.sh "<workId URL>" baseline-cold 5   # 착수 전
+./measure-lcp.sh "<workId URL>" ssr-cold 5        # 구현 후
+```
+- HTML 소스(view-source)에 첫 이미지 `<link rel="preload" as="image">` 존재 확인.
+- 네트워크 워터폴에서 첫 이미지 요청이 JS 번들/하이드레이션 **이전** 시작인지 육안 확인.
+- `summary.json`의 `LCP_LoadDelay_median` / `LCP_ms_median`으로 게이트 판정.
+
+## 8. 롤백
+
+- preload 링크 렌더 제거 + 서버 fetch 비활성화로 원복. 경계 분리는 남겨도 무해.

--- a/docs/plans/first-image-loading/03-image-prefetch.md
+++ b/docs/plans/first-image-loading/03-image-prefetch.md
@@ -1,0 +1,70 @@
+# 계획서 ③: 이미지 prefetch (비용 제어형)
+
+> 상태: **초안 (구현 보류)**
+> 난이도: 중간 · 디자인 변화: 없음 · Storage 비용: 콜드 미스분만 (제어 가능)
+
+## 1. 목표
+
+강한 인텐트 시점에 **첫 이미지 1장의 바이트**를 미리 받아둬, 클릭 후 브라우저 캐시에서 거의 즉시 표시. 체감 개선 폭이 가장 크다.
+
+- ①(데이터 prefetch)이 URL을 당긴다면, ③은 **바이트**까지 당긴다.
+- 단독으로도 동작하나 ①과 함께 쓰면 URL·바이트 모두 워밍.
+
+## 2. 비용 모델 (중요)
+
+프로덕션은 브라우저가 Storage에서 직접 받지 않고 **`/_next/image` 최적화 캐시**(`minimumCacheTTL` 31일)를 거친다.
+
+- 같은 변형을 여러 번 prefetch해도 **Firebase Storage egress는 31일에 콜드 미스 1회**. 나머지는 호스트/CDN 대역폭.
+- 따라서 prefetch가 늘리는 Storage 비용 = "그 기간 아무도 안 받은 새 변형 × 크기". 인기 작품일수록 0에 수렴.
+- **진짜 낭비** = (안 열 작품) × (캐시에도 없음) × (콜드로 Storage 깨움). → 인텐트 게이팅으로 차단.
+
+## 3. 비용 제어 규칙
+
+1. **작품당 첫 이미지 1장만** prefetch (전체 이미지 X).
+2. **강한 인텐트에서만 발사**:
+   - 데스크톱: 호버 **150~200ms 유지** 시 (스쳐 지나간 호버 제외).
+   - 모바일: `touchstart`/`pointerdown`(탭 직전).
+3. **중복 차단**: 이미 prefetch/캐시한 URL은 `Set`으로 기록해 재발사 금지.
+4. **뷰포트/네트워크 가드(선택)**: `navigator.connection.saveData`나 느린 연결(2g/3g)에서는 스킵.
+
+## 4. 구현 방식
+
+- prefetch 대상은 **next/image 실제 변형 URL**이어야 캐시 적중. ②의 변형 URL 구성 유틸을 공유.
+  - 방법 A: `<link rel="prefetch" as="image" imagesrcset=... imagesizes=...>`를 동적으로 head에 append.
+  - 방법 B: `const img = new Image(); img.src = '/_next/image?url=...&w=...&q=72'` 로 단일 변형 워밍(간단, 단 sizes 분기 손실 → 대표 폭 1개 선택).
+- 추천: **방법 A**(sizes 분기 유지) + 인텐트 디바운스 래퍼 훅 `usePrefetchFirstImage(work)`.
+- 호출 지점:
+  - 홈 `WorkTitleButton`: 기존 `onMouseEnter`의 데이터 prefetch 옆에, 디바운스 후 이미지 prefetch 추가.
+  - 캡션 링크/`FloatingWorkWindow`: 호버 인텐트 시 동일 훅 호출.
+
+## 5. 변경 파일(예상)
+
+- `front/src/domain/hooks/usePrefetchFirstImage.ts` (신규) — 변형 URL 구성 + 인텐트 디바운스 + 중복 Set.
+- `front/src/presentation/components/work/WorkTitleButton.tsx` — 호버/터치 인텐트에서 호출.
+- `front/src/domain/hooks/useCaptionHoverEvents.ts` — 캡션 링크 인텐트에서 호출.
+- 변형 URL 유틸은 ②와 공유(`buildNextImageUrl`).
+
+## 6. 리스크 / 주의
+
+- **변형 URL 불일치 = 캐시 미적중 + 이중 다운로드**: `w/q/sizes`를 ②와 동일 상수로.
+- **저사양/데이터 절약 모드 낭비**: saveData 가드로 완화.
+- **모바일 touchstart 오발화**: 스크롤 제스처 구분(이동 임계) 또는 첫 1장·중복차단으로 비용 상한 유지.
+- 이미지 prefetch는 ①·②와 달리 실제 대역폭을 쓰므로, **인텐트 게이팅이 무력화되지 않도록** 디바운스 로직을 우선 검증.
+
+## 7. 검증 — 측정 가능한 벤치마크
+
+> 합격 기준 전문: [BENCHMARKS.md §4 ③](./BENCHMARKS.md#4-plan별-합격-기준-pass-gate)
+
+**Pass gate:**
+- 클릭 후 첫 이미지 **Load Time ≈ 0**(disk/memory 캐시 히트, 재전송 없음).
+- 인텐트 미충족 호버(스쳐 지나감)에서 `/_next/image` 요청 **0건**(낭비 차단).
+- 콜드 미스 노출 = 작품당 **최대 1 변형**(첫 이미지 1장 한정).
+
+**측정 절차:**
+- DevTools 네트워크 탭: 호버 150ms+ 유지 시에만 첫 이미지 prefetch 발생, 짧은 호버엔 미발생 확인.
+- 클릭 후 첫 이미지가 `(from disk cache)` / `(from memory cache)`로 로드되는지 확인.
+- Performance 트레이스로 클릭→LCP 구간 before/after 비교(클라이언트 네비라 Lighthouse 대신).
+
+## 8. 롤백
+
+- 인텐트 훅 호출 제거로 원복. 데이터/타입 변경 없음.

--- a/docs/plans/first-image-loading/BENCHMARKS.md
+++ b/docs/plans/first-image-loading/BENCHMARKS.md
@@ -1,0 +1,101 @@
+# 벤치마크 — 측정 방법 · 베이스라인 · plan별 합격 기준
+
+> 각 plan은 "체감이 좋아졌다"가 아니라 **숫자로 통과/실패**가 판정돼야 한다.
+> 측정기: [`measure-lcp.sh`](./measure-lcp.sh) (Lighthouse 12.x, mobile, N회 중앙값).
+
+## 1. 측정 방법 (공통 프로토콜)
+
+- **도구**: Lighthouse mobile(throttling 기본), 기존 리포트와 동일 form factor.
+- **대상 URL**: 테스트 작품 고정
+  `https://hyebinna.com/?exhibitionId=6YOWXaVDmK54vzBZph7H&workId=9Ehrmcpebh5mZwRv8qGF`
+- **표본**: plan 적용 전/후 각 **5회 측정 → 중앙값**(분산 큰 LCP 보정).
+- **핵심 지표**: LCP 총합 + **단계 분해**(TTFB / Load Delay / Load Time / Render Delay).
+  이 분해가 plan별 타깃 구간을 직접 가리킨다.
+- **캐시 상태 구분**: `/_next/image` 엣지 캐시 워밍 여부가 Load Time을 좌우 →
+  라벨을 `*-cold` / `*-warm`으로 나눠 측정. **Load Delay는 캐시 무관**이라 워터폴 plan(①②③)의 1차 KPI.
+
+```bash
+cd docs/plans/first-image-loading
+./measure-lcp.sh "<URL>" baseline-cold 5     # plan 적용 전
+# ... plan 구현 후 ...
+./measure-lcp.sh "<URL>" plan2-cold 5        # plan 적용 후 (같은 URL/조건)
+```
+
+> 운영 URL 대신 로컬 `npm run build && npm start` 빌드를 측정해도 됨(코드 변경을 배포 전 검증). 단 cold/warm·throttling을 동일하게 유지.
+
+## 2. 베이스라인 (현재값, 기존 리포트에서 추출)
+
+| 지표 | cold 런(`lh-detail`) | warm 런(`lh-detail-after`) |
+|---|---|---|
+| Perf score | 57 | 68 |
+| FCP | 3,935 ms | 2,730 ms |
+| **LCP** | **14,838 ms** | **7,545 ms** |
+| Speed Index | 8,931 ms | 5,236 ms |
+| TBT | 120 ms | 37 ms |
+| LCP·TTFB | 642 ms | 850 ms |
+| **LCP·Load Delay** | 1,931 ms | **4,332 ms** |
+| **LCP·Load Time** | **10,661 ms** | 160 ms |
+| LCP·Render Delay | 1,603 ms | 2,201 ms |
+| 총 전송량 | 2,346 KB | 1,382 KB |
+
+> ⚠️ 두 런은 캐시 상태가 달라(특히 Load Time 10,661ms vs 160ms) 1:1 비교가 아님.
+> **구현 착수 전 5회 중앙값으로 cold/warm 베이스라인을 다시 고정**하는 것이 step 0.
+> LCP 요소는 두 런 모두 **첫 상세 이미지 `<img>`**(2500×4096, AVIF via `/_next/image`)로 확인됨 → 우리가 줄이려는 대상과 일치.
+
+## 3. LCP 단계 → plan 매핑
+
+| LCP 단계 | 의미 | 줄이는 plan |
+|---|---|---|
+| TTFB | 서버 응답 | (범위 밖) |
+| **Load Delay** | FCP~이미지 요청 시작 = CSR 워터폴(하이드→쿼리→Firestore→URL) | **② SSR/preload, ① 데이터 prefetch, ③ 이미지 prefetch** |
+| **Load Time** | 이미지 다운로드 | **③ 이미지 prefetch**(클릭 시 캐시 히트), (간접) 기존 AVIF/캐시 |
+| Render Delay | 페인트까지 지연 | ④ LQIP(첫 형상 즉시 → 체감), 일부 ② |
+
+## 4. plan별 합격 기준 (pass gate)
+
+각 plan은 아래 게이트를 **5회 중앙값**으로 충족해야 "완료".
+
+### ① 데이터 prefetch 보강
+- **시나리오**: SPA 내부 네비게이션(목록/캡션/모바일에서 작품 진입).
+- **측정**: 진입 인텐트(호버/터치) → 클릭 시 `useWork`가 **캐시 히트**(네트워크 탭에 Firestore 문서 추가 요청 0).
+- **게이트**:
+  - 클릭 후 Firestore getDoc 추가 요청 **0건**(prefetch로 충족).
+  - 클릭→첫 이미지 요청 시작까지의 지연(Load Delay 상당) **≥ 30% 단축**(캡션 링크·모바일 경로).
+- **부수**: Storage egress 증가 없음(Firestore read만), 회귀 없음.
+
+### ② SSR / preload
+- **시나리오**: `workId` 직접 진입(cold).
+- **측정**: HTML 소스에 첫 이미지 `<link rel="preload" as="image">` 존재 + 네트워크 워터폴에서 **첫 이미지 요청이 JS 번들/하이드레이션 이전**에 시작.
+- **게이트** (cold, 5회 중앙값):
+  - **LCP·Load Delay: 4,332ms → ≤ 1,500ms** (≈ TTFB+α 수준까지).
+  - **LCP 총합: baseline 대비 ≥ 25% 단축**.
+  - preload URL과 next/image 실제 요청 URL **일치**(이중 다운로드 0 — 네트워크에 중복 변형 없음).
+
+### ③ 이미지 prefetch
+- **시나리오**: SPA 내부 네비게이션, 강한 인텐트(호버 150ms+/touchstart).
+- **측정**: 인텐트 시 첫 이미지 변형 prefetch → 클릭 후 **disk/memory 캐시 히트**.
+- **게이트**:
+  - 클릭 후 첫 이미지 **Load Time ≈ 0**(캐시 히트, 재전송 없음).
+  - 안 열고 지나간 작품엔 prefetch **미발사**(낭비 차단: 인텐트 미충족 호버에서 `/_next/image` 요청 0).
+  - 콜드 미스 노출 = 작품당 최대 **1 변형**(첫 이미지 1장 한정 확인).
+
+### ④ LQIP 블러
+- **주의**: LCP 요소는 여전히 실이미지라 **LCP 총합은 크게 안 변할 수 있음** → LCP만으로 판정하지 말 것.
+- **측정(체감 프록시)**: 이미지 컨테이너의 **첫 non-blank paint 시각**(블러 표시) — 트레이스/스크린샷 타임라인 또는 `element-render-delay` 관찰.
+- **게이트**:
+  - 첫 형상(블러) paint **≤ FCP 근처**(0ms급, 스켈레톤 1.2s 지연 제거 확인).
+  - 추가 전송량 **장당 ≤ 2KB**(인라인 data URL 상한), 총 문서 크기 회귀 없음.
+  - LCP·Speed Index **악화 없음**(±5% 이내).
+
+## 5. 결과 기록 템플릿
+
+각 plan PR에 아래 표를 첨부(측정기 `summary.json`에서 전사).
+
+| 지표 | before(중앙값) | after(중앙값) | Δ | 게이트 통과 |
+|---|---|---|---|---|
+| LCP | | | | |
+| LCP·Load Delay | | | | |
+| LCP·Load Time | | | | |
+| FCP | | | | |
+| Speed Index | | | | |
+| 총 전송량 | | | | |

--- a/docs/plans/first-image-loading/README.md
+++ b/docs/plans/first-image-loading/README.md
@@ -1,0 +1,49 @@
+# 첫 이미지 로딩 체감 개선 — 계획 묶음
+
+> 목표: 상세 화면에서 **첫 이미지가 뜨는 체감 속도** 개선
+> 작성일: 2026-06-23
+> 진행 방식: 계획서별로 **하나씩 구현 → 검증(Lighthouse/수동) → 다음**
+
+## 배경: 현재 워터폴
+
+상세 화면은 SPA(`?workId=`) + 클라이언트 전용 Firebase SDK 구조라, 첫 이미지까지 다음 직렬 경로를 탄다.
+
+```
+HTML → JS 번들 → 하이드레이션 → useWork() React Query → Firestore getDoc()
+→ 그제서야 image.url 확보 → /_next/image 요청 → AVIF 변환 → 다운로드 → 표시
+```
+
+`force-dynamic`이지만 상세 데이터는 클라이언트에서 받으므로, Next가 `priority` 이미지에 자동으로 넣는 `<link rel="preload" as="image">`가 **HTML에 들어가지 못한다**(서버가 URL을 모름). 즉 priority가 사실상 무력.
+
+## 4가지 개선 방식 비교
+
+| # | 방식 | 첫 이미지 체감 | 디자인 변화 | Firebase Storage 추가 비용 | 난이도 |
+|---|------|------|------|------|------|
+| 1 | **데이터 prefetch 보강** | 중간 | 없음 | ~0 (Firestore read) | 낮음 |
+| 2 | **SSR/preload** | 큼 (워터폴 제거) | 없음 | 0 | 높음 |
+| 3 | **이미지 prefetch** | 가장 큼 | 없음 | 콜드 미스분만 (제어 가능) | 중간 |
+| 4 | **LQIP 블러** | 큼 (0ms 형상) | **있음** (열화 이미지 노출) | 0 | 중간 |
+
+> 핵심: 프로덕션은 `/_next/image` 엣지 캐시(`minimumCacheTTL` 31일)가 앞단에 있어, 이미지 바이트를 여러 번 당겨도 **Firebase Storage egress는 콜드 미스 1회**만 발생. 따라서 3번의 실제 Storage 부담은 "아무도 안 받은 새 변형"에 한정.
+
+## 권장 구현 순서
+
+디자인 유지 + 비용 0을 우선하고, 쉬운 것부터 워밍업해 큰 것으로:
+
+1. **[데이터 prefetch 보강](./01-data-prefetch.md)** — 비용·디자인·위험 모두 최저. 캡션/모바일 경로의 누락된 prefetch를 채워 워터폴의 "데이터 leg"를 클릭 전에 끝낸다.
+2. **[SSR/preload](./02-ssr-preload.md)** — 효과 가장 근본적. 서버에서 첫 이미지 URL을 확보해 `<link rel="preload" as="image">`를 HTML에 주입, 워터폴의 JS·하이드레이션·쿼리 구간을 첫 이미지에서 제거.
+3. **[이미지 prefetch](./03-image-prefetch.md)** — 강한 인텐트 + 첫 1장으로 제한해 비용을 통제하며 클릭 후 거의 즉시 표시.
+4. **[LQIP 블러](../lqip-blur-placeholder.md)** — 디자인 방향(열화 이미지 노출 허용)을 바꾸기로 결정한 경우에만. 절충안으로 "단색 플레이스홀더" 검토.
+
+각 단계는 독립적으로 켜고 끌 수 있으며, 효과는 상호 배타가 아니라 **누적**된다.
+
+## 검증 / 벤치마크 (공통)
+
+측정 방법·베이스라인·plan별 합격 기준은 **[BENCHMARKS.md](./BENCHMARKS.md)** 에 정량 정의.
+재현 측정기는 **[`measure-lcp.sh`](./measure-lcp.sh)** (Lighthouse mobile, 5회 중앙값).
+
+- 핵심 지표: **LCP + 단계 분해**(TTFB / Load Delay / Load Time / Render Delay).
+  - LCP 요소 = 첫 상세 이미지 `<img>`(확인됨). Load Delay = CSR 워터폴 구간.
+- 각 plan은 BENCHMARKS §4의 **pass gate를 5회 중앙값으로 충족**해야 완료.
+- 착수 전 cold/warm 베이스라인을 `measure-lcp.sh`로 재고정(step 0).
+```

--- a/docs/plans/first-image-loading/measure-lcp.sh
+++ b/docs/plans/first-image-loading/measure-lcp.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# 첫 이미지 로딩 벤치마크 측정 하네스
+#
+# 같은 URL을 Lighthouse(mobile)로 N회 돌려 LCP와 그 단계 분해(TTFB/Load Delay/
+# Load Time/Render Delay)의 "중앙값"을 뽑는다. 각 plan 적용 전/후를 동일 조건으로
+# 비교하기 위한 기준 측정기.
+#
+# 사용법:
+#   ./measure-lcp.sh <URL> <LABEL> [RUNS]
+# 예:
+#   ./measure-lcp.sh "https://hyebinna.com/?exhibitionId=6YOWXaVDmK54vzBZph7H&workId=9Ehrmcpebh5mZwRv8qGF" baseline 5
+#
+# 출력: ./lh-runs/<LABEL>/ 에 run-*.json 저장 + 중앙값 요약을 stdout/summary.txt 로.
+#
+# 주의(캐시 상태):
+#   - Load Delay 는 클라이언트 워터폴 지표라 캐시와 무관 → plan ①②③ 의 1차 KPI.
+#   - Load Time 은 /_next/image 엣지 캐시 워밍 여부에 크게 좌우됨 → cold/warm 을
+#     라벨로 구분해 측정할 것(예: baseline-cold / baseline-warm).
+set -euo pipefail
+
+URL="${1:?URL 필요}"
+LABEL="${2:?LABEL 필요}"
+RUNS="${3:-5}"
+
+OUTDIR="$(dirname "$0")/lh-runs/$LABEL"
+mkdir -p "$OUTDIR"
+
+echo "▶ measuring '$LABEL' : $RUNS runs (mobile)"
+for i in $(seq 1 "$RUNS"); do
+  echo "  run $i/$RUNS ..."
+  npx --yes lighthouse "$URL" \
+    --only-categories=performance \
+    --form-factor=mobile \
+    --output=json \
+    --output-path="$OUTDIR/run-$i.json" \
+    --chrome-flags="--headless=new" \
+    --quiet >/dev/null 2>&1 || { echo "  run $i 실패"; continue; }
+done
+
+echo "▶ aggregating medians ..."
+jq -s '
+  def median(arr): (arr|sort) as $s | ($s|length) as $n
+    | if $n==0 then 0 elif ($n%2==1) then $s[($n/2|floor)] else (($s[$n/2-1]+$s[$n/2])/2) end;
+  def lcpPhase($p): map(.audits["largest-contentful-paint-element"].details.items[1].items[]?
+      | select(.phase==$p) | .timing) ;
+  {
+    label: "'"$LABEL"'",
+    runs: length,
+    perfScore_median: (median([.[].categories.performance.score]) * 100 | floor),
+    FCP_ms_median:    (median([.[].audits["first-contentful-paint"].numericValue]) | floor),
+    LCP_ms_median:    (median([.[].audits["largest-contentful-paint"].numericValue]) | floor),
+    SI_ms_median:     (median([.[].audits["speed-index"].numericValue]) | floor),
+    TBT_ms_median:    (median([.[].audits["total-blocking-time"].numericValue]) | floor),
+    LCP_TTFB_median:        (median(lcpPhase("TTFB")) | floor),
+    LCP_LoadDelay_median:   (median(lcpPhase("Load Delay")) | floor),
+    LCP_LoadTime_median:    (median(lcpPhase("Load Time")) | floor),
+    LCP_RenderDelay_median: (median(lcpPhase("Render Delay")) | floor)
+  }
+' "$OUTDIR"/run-*.json | tee "$OUTDIR/summary.json"
+
+echo "✔ saved → $OUTDIR/summary.json"

--- a/docs/plans/lqip-blur-placeholder.md
+++ b/docs/plans/lqip-blur-placeholder.md
@@ -1,0 +1,140 @@
+# 계획서: LQIP 블러 플레이스홀더 도입
+
+> 상태: **초안 (구현 보류)**
+> 작성일: 2026-06-23
+> 목표: 상세 화면에서 **첫 이미지가 뜨는 체감 로딩 속도** 개선
+
+---
+
+## 1. 배경 / 문제
+
+현재 상세 화면의 이미지 로딩 체감 흐름은 다음과 같다.
+
+```
+빈 화면 (수백 ms ~ 1.2s) → 스켈레톤 시머 → 실제 이미지 fade-in
+```
+
+- `FadeInImage`는 `placeholder` 없이 `next/image`를 쓰고, 로딩이 1.2초(`SKELETON_DELAY_MS`)를 넘겨야 스켈레톤을 띄운다.
+- 그 전까지는 **레이아웃 박스만 있고 아무 형상이 없어** "비어 있다"는 인상을 준다.
+- 실제 다운로드 시간을 줄이지 않더라도, **0ms에 흐릿한 형상**을 먼저 보여주면 체감 속도가 크게 개선된다 (LQIP 기법).
+
+## 2. 접근 방식
+
+업로드 시점에 **초저해상도(가로 ~20px) 블러 이미지를 base64 data URL로 생성**해 Firestore 문서에 인라인 저장하고, front에서 `next/image`의 `placeholder="blur"` + `blurDataURL`로 사용한다.
+
+- 별도 Storage 업로드/네트워크 요청 없음 — data URL이 작품 데이터(JSON)에 함께 실려 온다.
+- admin이 이미 Canvas로 썸네일을 만들고 있어, **같은 1회 디코딩 파이프라인에 변형 하나만 추가**하면 된다.
+
+### 왜 data URL 인라인인가
+
+| 방식 | 장점 | 단점 | 채택 |
+|------|------|------|------|
+| **base64 data URL 인라인 (Firestore)** | 추가 네트워크 0회, 데이터와 함께 즉시 도착 | 문서 크기 약간 증가 | ✅ |
+| Storage에 별도 LQIP 파일 업로드 | 문서 가벼움 | 첫 형상까지 네트워크 1회 추가 → 체감 개선 효과 반감 | ✗ |
+| front 런타임에 thumbnailUrl fetch 후 생성 | 데이터 모델 변경 없음 | CORS·디코딩·네트워크 추가, 복잡 | ✗ |
+
+### data URL 크기 가늠
+
+- 가로 약 20px(비율 유지) WebP/JPEG → 대략 **0.3~1KB / 장**.
+- 한 작품 이미지 수가 많아도 Firestore 1MB 문서 한도 대비 여유. (예: 30장 × 1KB ≈ 30KB)
+- 단, 안전장치로 생성 후 길이를 검증하고 상한(예: 2KB)을 넘으면 품질/크기를 더 낮춘다.
+
+## 3. 데이터 모델 변경
+
+`WorkImage`에 선택 필드 추가 — **front / admin 양쪽 동일하게**.
+
+```ts
+export interface WorkImage {
+  // ...기존 필드
+  /** LQIP 블러 플레이스홀더 (base64 data URL, 가로 ~20px). 신규 업로드부터 채워짐 */
+  blurDataURL?: string;
+}
+```
+
+- 위치
+  - front: `front/src/core/types/work.types.ts`
+  - admin: `admin/src/core/types/api.ts`
+- **선택값**으로 둬서 기존 데이터(필드 없음)와 호환. 없으면 front는 기존 스켈레톤 fallback.
+
+## 4. 변경 대상 파일
+
+### admin (생성·저장)
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `admin/src/core/utils/image.ts` | `processImage()`에 LQIP 변형 생성 추가 — Canvas로 가로 ~20px 축소 후 `toDataURL`. 결과를 반환 객체에 `blurDataURL`로 포함. 크기 상한 검증 포함 |
+| `admin/src/data/api/storageApi.ts` | `uploadImage()`에서 `processImage` 결과의 `blurDataURL`을 `WorkImage`에 실어 반환 |
+| `admin/src/core/utils/imageUploadMerge.ts` | `mergeUploadedImages()`에서 temp→real 병합 시 `blurDataURL` 승계 |
+| `admin/src/core/types/api.ts` | `WorkImage.blurDataURL` 추가 |
+| (저장 sanitize 지점) `admin/src/pages/WorkForm.tsx` | `sanitizedImages` 구성 시 `blurDataURL` 누락되지 않도록 확인 |
+
+### front (소비)
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `front/src/core/types/work.types.ts` | `WorkImage.blurDataURL` 추가 |
+| `front/src/presentation/ui/media/FadeInImage.tsx` | `blurDataURL?` prop 추가 → 있으면 `next/image`에 `placeholder="blur"` + `blurDataURL` 전달. 있을 때는 커스텀 스켈레톤/opacity 게이트 비활성화 |
+| `front/app/works/WorkDetailPage.tsx` | 인라인 `FadeInImage`에 `blurDataURL={item.data.blurDataURL}` 전달 (경로 1) |
+| `front/src/presentation/components/work/ModalImage.tsx` | `FadeInImage`에 `blurDataURL={image.blurDataURL}` 전달 (경로 2) |
+
+> ⚠️ **이중 렌더 경로**: 상세 화면 인라인(`WorkDetailPage`)과 모달(`ModalImage`) 두 곳 모두 수정해야 함. ([[front-detail-two-image-render-paths]])
+
+## 5. FadeInImage 렌더 로직 정리
+
+`blurDataURL` 유무에 따라 동작을 분기한다.
+
+- **blurDataURL 있음**:
+  - `<Image placeholder="blur" blurDataURL={...} />` → next/image가 0ms에 흐릿한 형상 표시.
+  - 커스텀 스켈레톤(`showSkeleton`)·`SKELETON_DELAY_MS` 타이머 미사용.
+  - opacity fade 게이트도 불필요(블러가 자연스러운 전환을 대체). priority 여부와 무관하게 즉시 표시.
+- **blurDataURL 없음 (기존 데이터)**:
+  - 현재 동작 그대로 유지(스켈레톤 + fade).
+
+이렇게 하면 신규/기존 이미지가 한 컴포넌트에서 자연스럽게 공존한다.
+
+## 6. 기존 데이터 백필 전략
+
+신규 업로드는 자동으로 채워지지만, **기존 작품 이미지는 `blurDataURL`이 없다.**
+
+- **1단계(기본)**: 백필 없이 출시. 기존 이미지는 fallback(스켈레톤)으로 동작, 신규 업로드부터 LQIP 적용. → 위험 낮고 즉시 가능.
+- **2단계(선택)**: 일회성 마이그레이션. admin에서 기존 `images[].url`(또는 `thumbnailUrl`)을 불러와 Canvas로 LQIP 생성 후 문서 갱신.
+  - 주의: Firebase Storage CORS 설정 필요(Canvas `toDataURL`는 cross-origin 이미지에서 tainted canvas 오류 발생 가능). `crossOrigin="anonymous"` + Storage CORS 허용 확인.
+  - 범위가 크면 별도 작업으로 분리.
+
+## 7. 리스크 / 엣지 케이스
+
+- **문서 크기 팽창**: 이미지 다수 작품에서 누적. → 생성 시 길이 상한 검증, 가로 16~20px 유지.
+- **Tainted canvas (백필 시)**: cross-origin 제약. 신규 업로드 경로는 로컬 File이라 무관, 백필만 해당.
+- **placeholder="blur"의 width/height 요구**: 우리는 명시적 width/height를 넘기므로 충족.
+- **빈/실패 생성**: LQIP 생성 실패 시 `blurDataURL`을 비워 두고 fallback으로 동작(throw 금지).
+- **테스트 영향**: `FadeInImage`·`ModalImage` 스냅샷/렌더 테스트에 prop 추가 반영.
+
+## 8. 테스트 계획 / 측정 가능한 벤치마크
+
+> 합격 기준 전문: [BENCHMARKS.md §4 ④](./first-image-loading/BENCHMARKS.md#4-plan별-합격-기준-pass-gate)
+
+**단위 테스트:**
+- admin: `processImage()`가 유효한 data URL과 상한 이하 길이를 반환하는지.
+- admin: `mergeUploadedImages()`가 `blurDataURL`을 승계하는지.
+- front: `FadeInImage`가 `blurDataURL` 있을 때 `placeholder="blur"`로, 없을 때 스켈레톤 경로로 렌더되는지.
+
+**Pass gate (주의: LCP 요소는 실이미지라 LCP만으로 판정 금지):**
+- 첫 형상(블러) paint **≤ FCP 근처**(스켈레톤 1.2s 지연 제거 — 트레이스/스크린샷 타임라인으로 확인).
+- 추가 전송량 **장당 ≤ 2KB**(인라인 data URL 상한), 문서 크기 회귀 없음.
+- LCP·Speed Index **악화 없음(±5% 이내)** — `measure-lcp.sh`로 before/after 중앙값 대조.
+
+## 9. 작업 순서(예정)
+
+1. 타입 추가(front/admin `WorkImage.blurDataURL`).
+2. admin `processImage` LQIP 생성 + `storageApi`/`mergeUploadedImages` 배선.
+3. front `FadeInImage` 분기 로직.
+4. front 두 렌더 경로에 prop 전달.
+5. 테스트 추가/수정.
+6. 수동 검증(신규 업로드 1건) + Lighthouse 비교.
+7. (선택) 기존 데이터 백필 별도 진행.
+
+## 10. 롤백
+
+- 데이터 필드는 선택값이라 그대로 둬도 무해.
+- front에서 `blurDataURL` 전달만 제거하면 즉시 기존 동작으로 복귀.
+```


### PR DESCRIPTION
## 요약
상세 화면에서 **첫 이미지가 뜨는 체감 로딩 속도**를 개선하기 위한 계획 묶음과, 각 plan을 숫자로 판정할 **측정 가능한 벤치마크**를 추가합니다. 코드 변경 없음(문서/측정기만).

## 포함 내용
- `docs/plans/first-image-loading/README.md` — 4안 비교표 + 권장 구현 순서
- `01-data-prefetch.md` / `02-ssr-preload.md` / `03-image-prefetch.md` — 개별 계획서(변경 파일·리스크·롤백·합격기준)
- `lqip-blur-placeholder.md` — LQIP(블러) 계획서(디자인 변화 동반)
- `BENCHMARKS.md` — 측정 프로토콜 + **베이스라인 실측표** + LCP 단계→plan 매핑 + plan별 pass gate
- `measure-lcp.sh` — Lighthouse 5회 중앙값 측정기(jq 집계 로직 기존 리포트로 검증 완료)

## 베이스라인(기존 리포트 추출)
- LCP cold **14,838ms** / warm 7,545ms. LCP 요소 = 첫 상세 이미지 `<img>`.
- 단계 분해: Load Delay(CSR 워터폴)·Load Time(다운로드)이 지배 → 각 plan의 타깃 구간을 정량 매핑.

## 후속 PR(별도 브랜치)
- `perf/data-prefetch` (①) · `perf/ssr-preload` (②) · `perf/image-prefetch` (③) · `perf/lqip-blur` (④)

🤖 Generated with [Claude Code](https://claude.com/claude-code)