### PR TITLE
perf(lcp): 첫 이미지 SSR preload

### DIFF
--- a/front/app/HomeClient.tsx
+++ b/front/app/HomeClient.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Suspense, ReactElement } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+import { LoadingContainer } from '@/presentation/ui';
+import { useCategories } from '@/state';
+import WorkDetailPage from './works/WorkDetailPage';
+
+/**
+ * 홈페이지 클라이언트 로직 (Single Page Application)
+ *
+ * URL 구조:
+ * - 카테고리만: /?keywordId=xxx 또는 /?exhibitionId=xxx
+ * - 작품 상세: /?keywordId=xxx&workId=123
+ *
+ * workId가 있으면 WorkDetailPage를 조건부 렌더링.
+ *
+ * NOTE: 첫 진입 시 LCP 이미지의 SSR preload 링크는 부모 Server Component
+ * (app/page.tsx)에서 주입한다. 이 컴포넌트는 기존 UI/상호작용만 담당.
+ */
+function HomePageContent(): ReactElement {
+  const { isLoading } = useCategories();
+  const searchParams = useSearchParams();
+  const workId = searchParams.get('workId');
+
+  // workId가 있으면 카테고리 로딩을 기다리지 않고 즉시 상세를 렌더한다.
+  // 카테고리는 레이아웃 네비용일 뿐 상세 본문/LCP 이미지와 독립적이므로,
+  // 이 게이트를 두면 상세 LCP 이미지 로딩이 카테고리 왕복 뒤로 직렬화된다.
+  // workId가 없을 때(홈)만 카테고리 로딩 스피너를 표시한다.
+  if (!workId && isLoading) {
+    return <LoadingContainer size={24} />;
+  }
+
+  // workId가 있으면 작품 상세 페이지 표시 (부드러운 전환)
+  return (
+    <AnimatePresence mode="wait">
+      {workId && (
+        <motion.div
+          key={workId}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15, ease: 'easeOut' }}
+        >
+          <WorkDetailPage workId={workId} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default function HomeClient() {
+  return (
+    <Suspense fallback={<LoadingContainer size={24} />}>
+      <HomePageContent />
+    </Suspense>
+  );
+}

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,59 +1,57 @@
-'use client';
+import { ReactElement } from 'react';
+import {
+  DETAIL_IMAGE_SIZES,
+  DETAIL_IMAGE_QUALITY,
+} from '@/core/constants';
+import { buildPreloadImageSrcSet } from '@/core/utils';
+import { fetchFirstImageForPreload } from '@/data/api/worksServerApi';
+import HomeClient from './HomeClient';
 
-import { Suspense, ReactElement } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { motion, AnimatePresence } from 'framer-motion';
-import { LoadingContainer } from '@/presentation/ui';
-import { useCategories } from '@/state';
-import WorkDetailPage from './works/WorkDetailPage';
-
-// Disable static generation for this page (uses useSearchParams)
+// Disable static generation (상세는 searchParams 기반, 매 요청 동적 렌더).
 export const dynamic = 'force-dynamic';
 
 /**
- * 홈페이지 (Single Page Application)
+ * 홈페이지 (얇은 Server Component)
  *
- * URL 구조:
- * - 카테고리만: /?keywordId=xxx 또는 /?exhibitionId=xxx
- * - 작품 상세: /?keywordId=xxx&workId=123
+ * 역할:
+ * 1. URL에 workId가 있는 첫 진입(직접 링크/새로고침)이면, 서버에서 첫 이미지
+ *    URL을 알아내 <head>에 <link rel="preload" as="image">를 주입한다.
+ *    → 브라우저가 하이드레이션을 기다리지 않고 LCP 이미지를 즉시 받기 시작
+ *      (CSR 워터폴로 인한 "Load Delay" 제거).
+ * 2. 기존 클라이언트 UI는 HomeClient에서 그대로 렌더(동작 보존).
  *
- * workId가 있으면 WorkDetailPage를 조건부 렌더링
+ * preload는 best-effort다. 서버 조회가 null이면(미발행/이미지 없음/네트워크
+ * 실패/타임아웃) 링크를 생략하므로 기존 동작과 동일하다.
+ *
+ * Next.js 16에서 page의 searchParams는 Promise이므로 await 한다.
  */
-function HomePageContent(): ReactElement {
-  const { isLoading } = useCategories();
-  const searchParams = useSearchParams();
-  const workId = searchParams.get('workId');
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}): Promise<ReactElement> {
+  const params = await searchParams;
+  const rawWorkId = params.workId;
+  const workId = Array.isArray(rawWorkId) ? rawWorkId[0] : rawWorkId;
 
-  // workId가 있으면 카테고리 로딩을 기다리지 않고 즉시 상세를 렌더한다.
-  // 카테고리는 레이아웃 네비용일 뿐 상세 본문/LCP 이미지와 독립적이므로,
-  // 이 게이트를 두면 상세 LCP 이미지 로딩이 카테고리 왕복 뒤로 직렬화된다.
-  // workId가 없을 때(홈)만 카테고리 로딩 스피너를 표시한다.
-  if (!workId && isLoading) {
-    return <LoadingContainer size={24} />;
-  }
+  const preloadImage = workId ? await fetchFirstImageForPreload(workId) : null;
 
-  // workId가 있으면 작품 상세 페이지 표시 (부드러운 전환)
   return (
-    <AnimatePresence mode="wait">
-      {workId && (
-        <motion.div
-          key={workId}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.15, ease: 'easeOut' }}
-        >
-          <WorkDetailPage workId={workId} />
-        </motion.div>
+    <>
+      {preloadImage && (
+        // App Router에서 Server Component가 렌더한 <link>는 자동으로 <head>로 hoist된다.
+        // imageSrcSet/imageSizes를 next/image 변형과 동일하게 맞춰 이중 다운로드를 방지.
+        <link
+          rel="preload"
+          as="image"
+          imageSrcSet={buildPreloadImageSrcSet(preloadImage.url, {
+            quality: DETAIL_IMAGE_QUALITY,
+          })}
+          imageSizes={DETAIL_IMAGE_SIZES}
+          fetchPriority="high"
+        />
       )}
-    </AnimatePresence>
-  );
-}
-
-export default function HomePage() {
-  return (
-    <Suspense fallback={<LoadingContainer size={24} />}>
-      <HomePageContent />
-    </Suspense>
+      <HomeClient />
+    </>
   );
 }

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -34,7 +34,15 @@ export default async function HomePage({
   const rawWorkId = params.workId;
   const workId = Array.isArray(rawWorkId) ? rawWorkId[0] : rawWorkId;
 
-  const preloadImage = workId ? await fetchFirstImageForPreload(workId) : null;
+  // 에뮬레이터 모드에선 next.config가 images.unoptimized=true라 next/image가 원본 src를
+  // 그대로 렌더한다(=/_next/image 변형 없음). 이때 /_next/image preload는 실제 요청과
+  // 불일치해 낭비/404가 되므로 preload를 생략한다(로컬 전용이라 성능 영향 없음).
+  const isImageOptimizationDisabled =
+    process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 'true';
+  const preloadImage =
+    workId && !isImageOptimizationDisabled
+      ? await fetchFirstImageForPreload(workId)
+      : null;
 
   return (
     <>

--- a/front/app/works/WorkDetailPage.tsx
+++ b/front/app/works/WorkDetailPage.tsx
@@ -13,7 +13,11 @@
 import { useSearchParams } from 'next/navigation';
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { IS_DEBUG_LAYOUT_ENABLED } from '@/core/constants';
+import {
+  IS_DEBUG_LAYOUT_ENABLED,
+  DETAIL_IMAGE_SIZES,
+  DETAIL_IMAGE_QUALITY,
+} from '@/core/constants';
 import {
   Spinner,
   FloatingWorkWindow,
@@ -46,16 +50,8 @@ const SCROLL_CONSTANTS = {
   CENTER_SCORE_BASE: 1000,
 } as const;
 
-/**
- * 상세 페이지 인라인 이미지의 반응형 크기 힌트.
- * --media-width 브레이크포인트(모바일 100% / 768~1199px 60% / 데스크톱 ~50%)에 맞춰
- * next/image가 화면 폭에 맞는 변형을 선택하도록 한다(모바일 과대 전송 방지).
- * 줌(원본)은 ZoomableImage가 item.data.url을 직접 쓰므로 영향받지 않는다.
- */
-const DETAIL_IMAGE_SIZES = '(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw';
-
-/** 인라인 본문 이미지 품질(모달 본문과 동일, 화질 보존 우선). */
-const DETAIL_IMAGE_QUALITY = 72;
+// DETAIL_IMAGE_SIZES / DETAIL_IMAGE_QUALITY 는 SSR preload 링크(app/page.tsx)와
+// 동일해야 하므로 @/core/constants 에서 공유 import 한다.
 
 /**
  * Caption 내부의 작품 링크 컴포넌트

--- a/front/src/core/constants/image.constants.ts
+++ b/front/src/core/constants/image.constants.ts
@@ -1,0 +1,22 @@
+// 상세 화면 이미지 렌더 상수 (인라인 본문 이미지 + SSR preload 링크가 공유)
+
+/**
+ * 상세 페이지 인라인 이미지의 반응형 크기 힌트.
+ * --media-width 브레이크포인트(모바일 100% / 768~1199px 60% / 데스크톱 ~50%)에 맞춰
+ * next/image가 화면 폭에 맞는 변형을 선택하도록 한다(모바일 과대 전송 방지).
+ *
+ * 이 값은 WorkDetailPage 인라인 이미지의 `sizes`와 SSR preload 링크의
+ * `imagesizes`가 반드시 동일해야 하므로 한 곳에서 export 한다.
+ * (불일치 시 브라우저가 다른 변형을 선택해 이중 다운로드 낭비)
+ */
+export const DETAIL_IMAGE_SIZES =
+  '(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw';
+
+/** 인라인 본문 이미지 품질(모달 본문과 동일, 화질 보존 우선). */
+export const DETAIL_IMAGE_QUALITY = 72;
+
+/**
+ * next/image deviceSizes (next.config.ts와 동일하게 유지).
+ * preload srcset을 next/image 변형과 일치시키기 위해 사용한다.
+ */
+export const DETAIL_IMAGE_DEVICE_SIZES = [384, 640, 750, 828, 1080, 1200, 1920] as const;

--- a/front/src/core/constants/image.constants.ts
+++ b/front/src/core/constants/image.constants.ts
@@ -16,7 +16,32 @@ export const DETAIL_IMAGE_SIZES =
 export const DETAIL_IMAGE_QUALITY = 72;
 
 /**
- * next/image deviceSizes (next.config.ts와 동일하게 유지).
+ * next/image deviceSizes / imageSizes (next.config.ts와 동일하게 유지).
  * preload srcset을 next/image 변형과 일치시키기 위해 사용한다.
  */
 export const DETAIL_IMAGE_DEVICE_SIZES = [384, 640, 750, 828, 1080, 1200, 1920] as const;
+export const DETAIL_IMAGE_IMAGE_SIZES = [48, 80, 96, 160, 256, 300] as const;
+
+/**
+ * SSR preload 링크의 imagesrcset에 넣을 후보 폭.
+ *
+ * next/image는 `sizes`가 지정되면 srcset 후보를 deviceSizes만이 아니라
+ * (deviceSizes ∪ imageSizes) 중 `deviceSizes[0] * (최소 vw%)` 이상인 폭 전체로
+ * emit한다. DETAIL_IMAGE_SIZES의 최소 vw는 50% → 임계값 384*0.5=192 → 후보에
+ * imageSizes의 256·300도 포함된다.
+ *
+ * preload가 deviceSizes만 emit하면 브라우저가 실제 렌더에서 256/300을 선택할 때
+ * next/image엔 없는 폭을 preload한 셈이 되어 이중 다운로드가 발생한다. 그래서
+ * next/image의 후보 산출 로직을 동일하게 재현해 일치시킨다.
+ */
+const DETAIL_IMAGE_MIN_VW_RATIO =
+  Math.min(
+    ...[...DETAIL_IMAGE_SIZES.matchAll(/(\d+)vw/g)].map((m) => Number(m[1]))
+  ) * 0.01;
+
+export const DETAIL_IMAGE_PRELOAD_WIDTHS: readonly number[] = [
+  ...DETAIL_IMAGE_IMAGE_SIZES,
+  ...DETAIL_IMAGE_DEVICE_SIZES,
+]
+  .filter((w) => w >= DETAIL_IMAGE_DEVICE_SIZES[0] * DETAIL_IMAGE_MIN_VW_RATIO)
+  .sort((a, b) => a - b);

--- a/front/src/core/constants/index.ts
+++ b/front/src/core/constants/index.ts
@@ -5,3 +5,4 @@ export * from './routes.constants';
 export * from './animation.constants';
 export * from './debug.constants';
 export * from './color-palette.constants';
+export * from './image.constants';

--- a/front/src/core/utils/index.ts
+++ b/front/src/core/utils/index.ts
@@ -4,3 +4,4 @@ export * from './format.utils';
 export * from './media.utils';
 export * from './youtube.types';
 export { categoryAnimationStore } from './categoryAnimationStore';
+export * from './nextImageUrl';

--- a/front/src/core/utils/nextImageUrl.ts
+++ b/front/src/core/utils/nextImageUrl.ts
@@ -1,0 +1,39 @@
+// next/image 최적화 URL 빌더 (SSR preload 링크용)
+//
+// next/image는 런타임에 `/_next/image?url=...&w=...&q=...` 형태로 변형 이미지를
+// 요청한다. preload 링크의 `imagesrcset`을 이 형식과 정확히 일치시켜야
+// 브라우저가 하이드레이션 전에 받기 시작한 이미지를 next/image가 그대로 재사용한다.
+// (불일치 시 이중 다운로드 낭비)
+
+import { DETAIL_IMAGE_DEVICE_SIZES, DETAIL_IMAGE_QUALITY } from '@/core/constants';
+
+/**
+ * 단일 width에 대한 next/image 최적화 경로를 만든다.
+ */
+export function buildNextImageUrl(src: string, width: number, quality: number): string {
+  return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
+}
+
+interface BuildPreloadSrcSetOptions {
+  /** next.config.ts의 qualities에 등록된 값이어야 한다(기본 72). */
+  quality?: number;
+  /** next.config.ts의 deviceSizes와 동일해야 한다. */
+  widths?: readonly number[];
+}
+
+/**
+ * preload `<link imagesrcset>`에 넣을 srcset 문자열을 만든다.
+ * next/image가 생성하는 srcset과 동일한 후보 집합(각 deviceSize별 변형)을 제공한다.
+ *
+ * @example
+ *   buildPreloadImageSrcSet('https://.../a.jpg')
+ *   // "/_next/image?url=...&w=384&q=72 384w, /_next/image?url=...&w=640&q=72 640w, ..."
+ */
+export function buildPreloadImageSrcSet(
+  src: string,
+  { quality = DETAIL_IMAGE_QUALITY, widths = DETAIL_IMAGE_DEVICE_SIZES }: BuildPreloadSrcSetOptions = {}
+): string {
+  return widths
+    .map((w) => `${buildNextImageUrl(src, w, quality)} ${w}w`)
+    .join(', ');
+}

--- a/front/src/core/utils/nextImageUrl.ts
+++ b/front/src/core/utils/nextImageUrl.ts
@@ -5,7 +5,7 @@
 // 브라우저가 하이드레이션 전에 받기 시작한 이미지를 next/image가 그대로 재사용한다.
 // (불일치 시 이중 다운로드 낭비)
 
-import { DETAIL_IMAGE_DEVICE_SIZES, DETAIL_IMAGE_QUALITY } from '@/core/constants';
+import { DETAIL_IMAGE_PRELOAD_WIDTHS, DETAIL_IMAGE_QUALITY } from '@/core/constants';
 
 /**
  * 단일 width에 대한 next/image 최적화 경로를 만든다.
@@ -17,21 +17,22 @@ export function buildNextImageUrl(src: string, width: number, quality: number): 
 interface BuildPreloadSrcSetOptions {
   /** next.config.ts의 qualities에 등록된 값이어야 한다(기본 72). */
   quality?: number;
-  /** next.config.ts의 deviceSizes와 동일해야 한다. */
+  /** next/image가 실제 emit하는 후보 폭 집합과 동일해야 한다(기본 DETAIL_IMAGE_PRELOAD_WIDTHS). */
   widths?: readonly number[];
 }
 
 /**
  * preload `<link imagesrcset>`에 넣을 srcset 문자열을 만든다.
- * next/image가 생성하는 srcset과 동일한 후보 집합(각 deviceSize별 변형)을 제공한다.
+ * next/image가 `sizes` 지정 시 생성하는 srcset과 동일한 후보 집합
+ * (deviceSizes ∪ imageSizes 중 임계값 이상)을 제공해 이중 다운로드를 방지한다.
  *
  * @example
  *   buildPreloadImageSrcSet('https://.../a.jpg')
- *   // "/_next/image?url=...&w=384&q=72 384w, /_next/image?url=...&w=640&q=72 640w, ..."
+ *   // "/_next/image?url=...&w=256&q=72 256w, /_next/image?url=...&w=300&q=72 300w, ..."
  */
 export function buildPreloadImageSrcSet(
   src: string,
-  { quality = DETAIL_IMAGE_QUALITY, widths = DETAIL_IMAGE_DEVICE_SIZES }: BuildPreloadSrcSetOptions = {}
+  { quality = DETAIL_IMAGE_QUALITY, widths = DETAIL_IMAGE_PRELOAD_WIDTHS }: BuildPreloadSrcSetOptions = {}
 ): string {
   return widths
     .map((w) => `${buildNextImageUrl(src, w, quality)} ${w}w`)

--- a/front/src/data/api/worksServerApi.ts
+++ b/front/src/data/api/worksServerApi.ts
@@ -1,0 +1,131 @@
+// Works Server API — Firestore REST API로 첫 진입 SSR preload용 첫 이미지 메타 조회
+//
+// 배경: firebase-admin이 없어 서버에서 클라이언트 SDK(getDoc)를 쓸 수 없다.
+// 대신 Firestore REST API를 서버 fetch로 직접 호출해 필요한 필드(첫 이미지의
+// url/width/height)만 최소 파싱한다.
+//
+// 안전성 원칙: 이 함수는 절대 페이지 렌더를 깨면 안 된다.
+// 비-200 / 타임아웃 / 파싱 실패 / 미발행 / 이미지 없음 → 전부 null 반환(throw 금지).
+// null이면 호출부에서 preload 링크를 렌더하지 않아 기존 동작이 그대로 보존된다.
+
+import { FIREBASE_COLLECTIONS } from '@/core/constants';
+
+/** preload 대상 첫 이미지의 최소 메타. */
+export interface PreloadImageMeta {
+  url: string;
+  width: number;
+  height: number;
+}
+
+/** Firestore REST 응답의 typed value 래퍼(필요한 형태만 부분 정의). */
+interface FirestoreValue {
+  stringValue?: string;
+  integerValue?: string;
+  doubleValue?: number;
+  booleanValue?: boolean;
+  arrayValue?: { values?: FirestoreValue[] };
+  mapValue?: { fields?: Record<string, FirestoreValue> };
+}
+
+interface FirestoreDocument {
+  fields?: Record<string, FirestoreValue>;
+}
+
+/** REST 타임아웃(ms). 너무 길면 첫 진입 TTFB를 잡아먹으므로 짧게. */
+const FETCH_TIMEOUT_MS = 1500;
+
+/** Firestore typed value에서 number를 안전하게 추출. */
+function readNumber(value: FirestoreValue | undefined): number | null {
+  if (!value) return null;
+  if (typeof value.integerValue === 'string') {
+    const n = Number(value.integerValue);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (typeof value.doubleValue === 'number' && Number.isFinite(value.doubleValue)) {
+    return value.doubleValue;
+  }
+  return null;
+}
+
+/** Firestore typed value에서 string을 안전하게 추출. */
+function readString(value: FirestoreValue | undefined): string | null {
+  return typeof value?.stringValue === 'string' ? value.stringValue : null;
+}
+
+/**
+ * works/{id} 문서에서 order가 가장 작은 이미지의 url/width/height를 파싱한다.
+ * 어떤 단계든 누락/형식 이상이면 null.
+ */
+function parseFirstImageMeta(doc: FirestoreDocument): PreloadImageMeta | null {
+  const fields = doc.fields;
+  if (!fields) return null;
+
+  // 발행된 작품만 preload (상세 페이지가 미발행을 NotFound 처리하므로 일관)
+  if (fields.isPublished?.booleanValue !== true) return null;
+
+  const imageValues = fields.images?.arrayValue?.values;
+  if (!imageValues || imageValues.length === 0) return null;
+
+  // order 최소(없으면 배열 첫) 이미지 선택
+  let best: { meta: PreloadImageMeta; order: number } | null = null;
+
+  for (let i = 0; i < imageValues.length; i += 1) {
+    const imgFields = imageValues[i]?.mapValue?.fields;
+    if (!imgFields) continue;
+
+    const url = readString(imgFields.url);
+    const width = readNumber(imgFields.width);
+    const height = readNumber(imgFields.height);
+    if (!url || width === null || height === null || width <= 0 || height <= 0) {
+      continue;
+    }
+
+    const order = readNumber(imgFields.order) ?? i;
+    if (!best || order < best.order) {
+      best = { meta: { url, width, height }, order };
+    }
+  }
+
+  return best?.meta ?? null;
+}
+
+/**
+ * 첫 진입 SSR에서 preload할 첫 이미지 메타를 Firestore REST로 조회한다.
+ * 실패는 모두 null(graceful) — 호출부는 null이면 preload를 생략한다.
+ */
+export async function fetchFirstImageForPreload(
+  workId: string
+): Promise<PreloadImageMeta | null> {
+  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+
+  if (!projectId || !apiKey || !workId) return null;
+
+  const encodedId = encodeURIComponent(workId);
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}` +
+    `/databases/(default)/documents/${FIREBASE_COLLECTIONS.WORKS}/${encodedId}` +
+    `?key=${apiKey}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      // force-dynamic 페이지이므로 매 요청 최신값. (캐시 불일치로 인한 오작동 방지)
+      cache: 'no-store',
+    });
+
+    if (!res.ok) return null;
+
+    const doc = (await res.json()) as FirestoreDocument;
+    return parseFirstImageMeta(doc);
+  } catch {
+    // 타임아웃(abort), 네트워크, JSON 파싱 등 모든 예외를 흡수
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## 목적
URL에 `workId`가 있는 **첫 진입(직접 링크/새로고침)**에서, 서버가 첫 이미지 URL을 알아내 HTML `<head>`에 `<link rel="preload" as="image" fetchpriority="high">`를 주입한다. 브라우저가 하이드레이션을 기다리지 않고 LCP 이미지를 즉시 받기 시작 → LCP의 "Load Delay"(CSR 워터폴) 제거. 디자인/비용 변화 없음.

## 설계
### (A) 서버에서 첫 이미지 메타 확보 — Firestore REST API
- 신규 `front/src/data/api/worksServerApi.ts`의 `fetchFirstImageForPreload(workId)`.
- `firebase-admin`이 없어 클라이언트 SDK를 서버에서 못 쓰므로, Firestore REST(`https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents/works/${id}?key=${apiKey}`)를 서버 `fetch`로 직접 호출.
- `{fields:{...}}` typed-value 응답에서 `isPublished`/`images[].url|width|height|order`만 안전 파싱. order 최소(없으면 배열 첫) 이미지 선택.
- **graceful**: 비-200 / 타임아웃(AbortController 1.5s) / JSON 파싱 실패 / `isPublished!=true` / images 비어있음 / env 미설정 → **전부 `null`(throw 금지)**. null이면 preload 링크를 렌더하지 않아 기존 동작이 그대로 보존된다.

### (B) 서버/클라이언트 경계 분리 + preload 링크
- `front/app/page.tsx`를 **얇은 async Server Component**로 전환. 기존 `'use client'` 로직 전체를 신규 `front/app/HomeClient.tsx`로 이동(`useSearchParams`/Context/hook은 모두 클라이언트 경계 안).
- Next 16의 `searchParams`(Promise)를 `await`해 `workId`를 읽고, 있으면 `await fetchFirstImageForPreload`. 결과가 있으면 `<link rel="preload" as="image" imageSrcSet=... imageSizes=... fetchPriority="high">`를 렌더(Server Component의 `<link>`는 `<head>`로 hoist됨). 항상 `<HomeClient/>`를 렌더해 UI 보존.
- `export const dynamic = 'force-dynamic'` 유지.
- preload URL을 **next/image 실제 변형과 일치**시킴: 신규 `front/src/core/utils/nextImageUrl.ts`의 `buildPreloadImageSrcSet`이 deviceSizes별로 `/_next/image?url=...&w=${w}&q=72`를 조합. `imageSizes`는 `DETAIL_IMAGE_SIZES` **공유 상수**(`front/src/core/constants/image.constants.ts`)를 사용해 `WorkDetailPage`의 인라인 `sizes`와 동일 보장 → 이중 다운로드 방지.

## 변경 파일
- `front/app/page.tsx` — 얇은 Server Component로 전환, preload `<link>` 주입
- `front/app/HomeClient.tsx` (신규) — 기존 클라이언트 로직 이전
- `front/src/data/api/worksServerApi.ts` (신규) — Firestore REST 조회(graceful)
- `front/src/core/utils/nextImageUrl.ts` (신규) — next/image 일치 srcset 빌더
- `front/src/core/constants/image.constants.ts` (신규) — `DETAIL_IMAGE_SIZES`/`QUALITY`/`DEVICE_SIZES` 공유 상수
- `front/app/works/WorkDetailPage.tsx` — 로컬 상수를 공유 상수 import로 교체
- `front/src/core/{constants,utils}/index.ts` — 배럴 export 추가

## 합격 기준
- cold 5회 중앙값: LCP **Load Delay 4332ms → ≤1500ms**, LCP 총합 **≥25% 단축**
- preload URL과 next/image 실제 요청 일치(이중 다운로드 없음)
- workId 없는 홈에선 preload 링크 미주입, 미발행/이미지 없음/네트워크 실패 시 미주입(기존 동작 그대로)

## Graceful degradation
모든 실패 경로(env 미설정, REST 비-200, 1.5s 타임아웃, 파싱 실패, 미발행, 이미지 없음)에서 `null`을 반환하고 preload를 생략한다. 페이지 렌더는 어떤 경우에도 깨지지 않는다.

## 검증 결과
- `npm install` ✅
- `npm run lint` — 신규/변경 파일 0 errors. (기존 9 errors는 `MediaTimeline.tsx`/`WorkModal*.tsx` 등 본 PR과 무관한 main의 선재 문제로, `git stash`로 동일 재현 확인)
- `npm run test:run` — 212 passed. 실패 4건(`useKeywordState`/`useFloatingPosition`)은 본 PR과 무관한 선재 실패로, 변경 미적용 상태에서도 동일 실패 확인.
- `npm run build` ✅ — TypeScript 통과, `/`가 `ƒ (Dynamic)`으로 정상 분류.
- `npm start` 수동 확인: 홈(`/`)은 preload 링크 0개(정상), `?workId=...`는 **이 환경에 `.env*`가 없어** Firestore env가 undefined → graceful `null`로 preload 미주입(정상 동작). srcset 형식이 `/_next/image?url=...&w=384&q=72 384w` 등 next/image 형식과 일치함을 별도 검증.

## 실측 못 한 부분(솔직 보고)
- 이 환경엔 `front/.env*`가 없어 `NEXT_PUBLIC_FIREBASE_PROJECT_ID/API_KEY`가 비어 있고, 외부 Firestore 접근도 불가하다. 따라서 **실제 Firestore 응답 파싱 → preload 링크가 view-source에 주입되는 경로의 라이브 실측은 하지 못했다.** 다만 빌드/렌더/타입은 안전하며, env가 채워진 배포 환경에서 graceful 경로가 정상 동작함을 코드 수준으로 보장한다. 합격 기준의 LCP 수치(cold 5회 중앙값)도 동일 이유로 미실측이다 — 실제 Firestore 데이터가 있는 환경에서 검증 필요.

## 머지 순서 메모
②/③ 작업이 `nextImageUrl` 유틸을 공유하므로 머지 순서에 주의(충돌 시 본 유틸을 단일 소스로 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)