### PR TITLE
perf(prefetch): 캡션·모바일 진입 데이터 prefetch 보강

### DIFF
--- a/front/src/domain/hooks/useCaptionHoverEvents.ts
+++ b/front/src/domain/hooks/useCaptionHoverEvents.ts
@@ -13,6 +13,13 @@ export interface UseCaptionHoverEventsOptions {
   safeZoneMargin?: number;
   /** 현재 표시 중인 작업 ID (hover 대상에서 제외) */
   currentWorkId?: string;
+  /**
+   * 링크 hover 인텐트가 확정된 시점에 호출되는 콜백.
+   * FloatingWorkWindow 표시 직전에 작품 상세 데이터를 prefetch하기 위해 사용한다
+   * (예: usePrefetchWork()의 반환 콜백 주입). hoverDelay를 기다리지 않고
+   * 인텐트 확정 즉시 호출되어 Firestore 왕복을 클릭 전으로 옮긴다.
+   */
+  onLinkHoverIntent?: (workId: string) => void;
   /** DOM이 변경되었음을 알리는 의존성 배열 */
   dependencies?: React.DependencyList;
 }
@@ -70,6 +77,7 @@ export const useCaptionHoverEvents = ({
   hideDelay = 200,
   safeZoneMargin = 20,
   currentWorkId,
+  onLinkHoverIntent,
   dependencies = [],
 }: UseCaptionHoverEventsOptions): UseCaptionHoverEventsReturn => {
   // Hover 상태
@@ -86,6 +94,12 @@ export const useCaptionHoverEvents = ({
   // Ref for closure access
   const hoveredWorkIdRef = useRef<string | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
+
+  // 최신 prefetch 콜백을 ref로 보관 (이벤트 리스너 effect 재부착 방지)
+  const onLinkHoverIntentRef = useRef(onLinkHoverIntent);
+  useEffect(() => {
+    onLinkHoverIntentRef.current = onLinkHoverIntent;
+  }, [onLinkHoverIntent]);
 
   // MutationObserver
   const observerRef = useRef<MutationObserver | null>(null);
@@ -236,6 +250,9 @@ export const useCaptionHoverEvents = ({
 
         // 현재 작업과 동일한 링크는 hover 무시
         if (linkWorkId && linkWorkId !== currentWorkId) {
+          // 인텐트 확정 즉시 prefetch (hoverDelay를 기다리지 않음)
+          onLinkHoverIntentRef.current?.(linkWorkId);
+
           if (hoverLinkTimeoutRef.current) {
             clearTimeout(hoverLinkTimeoutRef.current);
             hoverLinkTimeoutRef.current = null;

--- a/front/src/presentation/__tests__/components/work/WorkModal.test.tsx
+++ b/front/src/presentation/__tests__/components/work/WorkModal.test.tsx
@@ -24,8 +24,11 @@ const mockUseImageTracker = vi.fn((_ref: unknown, _work: unknown, _id: unknown) 
   setCurrentImageId: vi.fn(),
 }));
 
+const mockPrefetchWork = vi.fn();
+
 vi.mock('@/domain', () => ({
   useWork: (id: string) => mockUseWork(id),
+  usePrefetchWork: () => mockPrefetchWork,
   useCaptionHoverEvents: (opts: unknown) => mockUseCaptionHoverEvents(opts),
   useModalLinkHandler: (onWorkClick: unknown, clearHover: unknown) =>
     mockUseModalLinkHandler(onWorkClick, clearHover),

--- a/front/src/presentation/__tests__/components/work/WorkModalMobile.test.tsx
+++ b/front/src/presentation/__tests__/components/work/WorkModalMobile.test.tsx
@@ -25,8 +25,11 @@ const mockUseImageTracker = vi.fn((_ref: unknown, _work: unknown, _id: unknown) 
   setCurrentImageId: vi.fn(),
 }));
 
+const mockPrefetchWork = vi.fn();
+
 vi.mock('@/domain', () => ({
   useWork: (id: string) => mockUseWork(id),
+  usePrefetchWork: () => mockPrefetchWork,
   useCaptionHoverEvents: (opts: unknown) => mockUseCaptionHoverEvents(opts),
   useModalLinkHandler: (onWorkClick: unknown, clearHover: unknown) =>
     mockUseModalLinkHandler(onWorkClick, clearHover),

--- a/front/src/presentation/components/work/WorkModal.tsx
+++ b/front/src/presentation/components/work/WorkModal.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
-import { useWork, useCaptionHoverEvents, useModalLinkHandler, useImageTracker } from '@/domain';
+import { useWork, useCaptionHoverEvents, useModalLinkHandler, useImageTracker, usePrefetchWork } from '@/domain';
 import { getMediaItems } from '@/core/utils';
 import { Spinner } from '@/presentation';
 import { YouTubeEmbed } from '../media';
@@ -44,11 +44,15 @@ export default function WorkModal({
 }: WorkModalProps) {
   const { data: modalWork, isLoading, isError } = useWork(workId);
 
+  // 캡션 링크 hover 인텐트 시 해당 작품 상세를 미리 가져와 클릭 시 즉시 렌더
+  const prefetchWork = usePrefetchWork();
+
   const { hoveredWorkId, hoverPosition, clearHover } = useCaptionHoverEvents({
     containerSelector: '[data-is-modal="true"]',
     hoverDelay: 400,
     hideDelay: 200,
     currentWorkId: modalWork?.id,
+    onLinkHoverIntent: prefetchWork,
     dependencies: [modalWork],
   });
 

--- a/front/src/presentation/components/work/WorkModalMobile.tsx
+++ b/front/src/presentation/components/work/WorkModalMobile.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
-import { useWork, useCaptionHoverEvents, useModalLinkHandler, useImageTracker } from '@/domain';
+import { useWork, useCaptionHoverEvents, useModalLinkHandler, useImageTracker, usePrefetchWork } from '@/domain';
 import { getMediaItems } from '@/core/utils';
 import { Spinner } from '@/presentation';
 import { YouTubeEmbed } from '../media';
@@ -39,11 +39,15 @@ export default function WorkModalMobile({
 }: WorkModalMobileProps) {
   const { data: modalWork, isLoading, isError } = useWork(workId);
 
+  // 캡션 링크 hover 인텐트 시 해당 작품 상세를 미리 가져와 클릭 시 즉시 렌더
+  const prefetchWork = usePrefetchWork();
+
   const { hoveredWorkId, hoverPosition, clearHover } = useCaptionHoverEvents({
     containerSelector: '[data-is-modal="true"]',
     hoverDelay: 400,
     hideDelay: 200,
     currentWorkId: modalWork?.id,
+    onLinkHoverIntent: prefetchWork,
     dependencies: [modalWork],
   });
 

--- a/front/src/presentation/components/work/WorkTitleButton.tsx
+++ b/front/src/presentation/components/work/WorkTitleButton.tsx
@@ -55,6 +55,12 @@ export default function WorkTitleButton({
   // 호버 시 상세 데이터를 미리 가져와 모달 진입 시 즉시 렌더(LCP 이미지 조기 로드)
   const prefetchWork = usePrefetchWork();
 
+  // 진입 인텐트(데스크톱 호버 / 모바일 터치)에서 상세 데이터 prefetch.
+  // 동일 키는 React Query가 dedupe하고 staleTime 내 재요청하지 않으므로 과호출 안전.
+  const handlePrefetchIntent = useCallback(() => {
+    prefetchWork(work.id);
+  }, [prefetchWork, work.id]);
+
   // Reset loading state when thumbnail URL changes
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect */
@@ -126,9 +132,11 @@ export default function WorkTitleButton({
       onClick={handleClick}
       onMouseEnter={() => {
         setIsHovered(true);
-        prefetchWork(work.id);
+        handlePrefetchIntent();
       }}
       onMouseLeave={() => setIsHovered(false)}
+      // 모바일: 호버가 없으므로 터치 시작(탭 인텐트)에 prefetch
+      onTouchStart={handlePrefetchIntent}
       style={{
         background: 'none',
         border: 'none',


### PR DESCRIPTION
## 변경 요약

작품 상세 진입 인텐트가 잡히는 순간 React Query 캐시를 미리 채워, 클릭 시 `useWork`가 캐시 히트하도록 한다. "하이드→쿼리→Firestore→URL 확보" 워터폴을 클릭 *전*으로 옮긴다. 비용은 Firestore read 1회(Storage egress 무관).

기존에 prefetch가 누락돼 있던 두 경로를 채웠다:

1. **캡션 링크 호버**: `useCaptionHoverEvents`에 `onLinkHoverIntent?: (workId) => void` 옵션 추가. 링크 hover 인텐트가 확정되는 즉시(`hoverDelay`를 기다리지 않고) 호출된다. 콜백은 ref로 보관해 이벤트 리스너 effect 재부착을 막는다. `WorkModal`/`WorkModalMobile`에서 `usePrefetchWork()` 반환 콜백을 주입.
2. **모바일 터치**: `WorkTitleButton`에 `onTouchStart` prefetch 추가(호버가 없는 모바일 대응). 기존 데스크톱 `onMouseEnter` prefetch와 동일한 `handlePrefetchIntent`(useCallback) 재사용.

동일 키는 React Query가 dedupe하고 staleTime(10분) 내 재요청하지 않으므로 과호출은 안전하며 추가 디바운스는 불필요하다. 기존 동작/시그니처 회귀 없음(옵션은 선택적 추가).

## 합격 기준 (측정 가능)

- 진입 인텐트(호버/터치) 후 클릭 시 Firestore `getDoc` 추가 요청 **0건** (캐시 히트, 동일 키 dedupe).
- 클릭 → 첫 이미지 요청까지의 지연 **≥30% 단축** (Firestore 왕복이 클릭 전으로 이동).

## 검증 결과

- `npm run build`: green (TypeScript 타입체크 포함 통과)
- `npm run test:run`: 변경된 두 모달 테스트 통과(`usePrefetchWork` 목 추가). 잔여 실패 4건(`useFloatingPosition`, `useKeywordState`)은 main에도 존재하는 기존 실패로 본 변경과 무관.
- `npm run lint`: main과 동일(9 errors/22 warnings, 모두 본 변경이 건드리지 않은 파일의 기존 문제). 본 변경이 추가한 신규 lint 문제 0건.

## 변경 파일

- `front/src/domain/hooks/useCaptionHoverEvents.ts`
- `front/src/presentation/components/work/WorkTitleButton.tsx`
- `front/src/presentation/components/work/WorkModal.tsx`
- `front/src/presentation/components/work/WorkModalMobile.tsx`
- `front/src/presentation/__tests__/components/work/WorkModal.test.tsx`
- `front/src/presentation/__tests__/components/work/WorkModalMobile.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)