### PR TITLE
feat(lqip): 첫 이미지 블러 플레이스홀더

### DIFF
--- a/admin/src/__tests__/core/utils/imageUploadMerge.test.ts
+++ b/admin/src/__tests__/core/utils/imageUploadMerge.test.ts
@@ -12,13 +12,14 @@ const tempImage = (id: string, caption?: string): WorkImage => ({
   ...(caption !== undefined ? { caption } : {}),
 });
 
-const uploadedImage = (id: string): WorkImage => ({
+const uploadedImage = (id: string, blurDataURL?: string): WorkImage => ({
   id,
   url: `https://cdn/${id}.jpg`,
   thumbnailUrl: `https://cdn/${id}-t.jpg`,
   order: 1,
   width: 800,
   height: 600,
+  ...(blurDataURL !== undefined ? { blurDataURL } : {}),
 });
 
 describe('mergeUploadedImages', () => {
@@ -62,6 +63,18 @@ describe('mergeUploadedImages', () => {
     expect(images).toHaveLength(1);
     expect(images[0].caption).toBe('A');
     expect(images[0].order).toBe(1);
+  });
+
+  it('업로드 결과의 blurDataURL(LQIP)이 병합 후에도 보존된다', () => {
+    const temp = tempImage('pending-1', 'cap');
+    const real = uploadedImage('real-1', 'data:image/webp;base64,AAAA');
+    const uploadedMap = new Map([['pending-1', real]]);
+
+    const { images } = mergeUploadedImages([temp], uploadedMap, new Set(), 'pending-1');
+
+    expect(images[0].blurDataURL).toBe('data:image/webp;base64,AAAA');
+    // caption도 동시에 승계되는지 회귀 확인
+    expect(images[0].caption).toBe('cap');
   });
 
   it('썸네일이 temp였다면 실제 ID로 교체된다', () => {

--- a/admin/src/__tests__/core/utils/processImageBlur.test.ts
+++ b/admin/src/__tests__/core/utils/processImageBlur.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { processImage } from '../../../core/utils/image';
+
+/**
+ * processImage의 LQIP(blurDataURL) 생성 경로 테스트.
+ *
+ * jsdom에는 실제 canvas 인코딩이 없으므로 Image / canvas API를 모킹하여
+ * - 상한 이하 data URL을 반환하는지
+ * - data URL이 과도하게 크면 재시도 후 빈 문자열로 graceful 처리하는지
+ * 를 검증한다.
+ */
+
+const PNG_TYPE = 'image/png';
+
+// toDataURL이 반환할 값을 테스트마다 제어
+let dataURLValue = 'data:image/webp;base64,SHORT';
+
+beforeEach(() => {
+  // URL object helpers
+  vi.stubGlobal('URL', {
+    createObjectURL: vi.fn(() => 'blob:mock'),
+    revokeObjectURL: vi.fn(),
+  });
+
+  // Image 모킹: src 설정 시 즉시 onload 호출
+  class MockImage {
+    width = 1600;
+    height = 1200;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      // microtask 후 onload 트리거
+      Promise.resolve().then(() => this.onload?.());
+    }
+  }
+  vi.stubGlobal('Image', MockImage as unknown as typeof Image);
+
+  // canvas getContext/toDataURL/toBlob 모킹
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    () => ({ drawImage: vi.fn() }) as unknown as CanvasRenderingContext2D
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockImplementation(
+    () => dataURLValue
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (
+    this: HTMLCanvasElement,
+    cb: BlobCallback
+  ) {
+    cb(new Blob(['x'], { type: 'image/webp' }));
+  } as HTMLCanvasElement['toBlob']);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const createFile = (): File => new File([new Blob([''], { type: PNG_TYPE })], 'a.png', { type: PNG_TYPE });
+
+const baseOptions = {
+  thumbnail: { maxWidth: 300, maxHeight: 300, quality: 0.7 },
+};
+
+describe('processImage - blurDataURL(LQIP)', () => {
+  it('상한 이하 data URL을 blurDataURL로 반환한다', async () => {
+    dataURLValue = 'data:image/webp;base64,' + 'A'.repeat(500);
+    const result = await processImage(createFile(), baseOptions);
+
+    expect(result.blurDataURL).toBe(dataURLValue);
+    expect(result.blurDataURL.length).toBeLessThanOrEqual(2048);
+  });
+
+  it('data URL이 상한을 항상 초과하면 빈 문자열로 graceful 처리한다', async () => {
+    // 모든 인코딩 시도에서 상한 초과(2048자 초과)
+    dataURLValue = 'data:image/webp;base64,' + 'A'.repeat(5000);
+    const result = await processImage(createFile(), baseOptions);
+
+    expect(result.blurDataURL).toBe('');
+  });
+
+  it('인코딩 중 오류가 나도 throw하지 않고 빈 문자열을 반환한다', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockImplementation(() => {
+      throw new Error('encode fail');
+    });
+    const result = await processImage(createFile(), baseOptions);
+
+    expect(result.blurDataURL).toBe('');
+    // 나머지 결과는 정상
+    expect(result.thumbnail).toBeInstanceOf(Blob);
+  });
+});

--- a/admin/src/__tests__/domain/hooks/useBlurBackfill.test.ts
+++ b/admin/src/__tests__/domain/hooks/useBlurBackfill.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../../../data/repository/worksRepository', () => ({
+  getWorks: vi.fn(),
+  updateWork: vi.fn(),
+}));
+vi.mock('../../../core/utils/image', () => ({
+  generateBlurDataURLFromUrl: vi.fn(),
+}));
+
+import { useBlurBackfill } from '../../../domain/hooks/useBlurBackfill';
+import { getWorks, updateWork } from '../../../data/repository/worksRepository';
+import { generateBlurDataURLFromUrl } from '../../../core/utils/image';
+import type { Work, WorkImage } from '../../../core/types';
+
+const mockGetWorks = vi.mocked(getWorks);
+const mockUpdateWork = vi.mocked(updateWork);
+const mockGen = vi.mocked(generateBlurDataURLFromUrl);
+
+const makeImage = (overrides: Partial<WorkImage>): WorkImage => ({
+  id: 'img',
+  url: 'https://cdn/o.jpg',
+  thumbnailUrl: 'https://cdn/t.jpg',
+  order: 1,
+  width: 100,
+  height: 100,
+  ...overrides,
+});
+
+const makeWork = (id: string, images: WorkImage[]): Work =>
+  ({ id, title: `work-${id}`, images } as unknown as Work);
+
+const runHook = async () => {
+  const { result } = renderHook(() => useBlurBackfill());
+  await act(async () => {
+    await result.current.run();
+  });
+  return result;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateWork.mockResolvedValue({} as Work);
+});
+
+describe('useBlurBackfill', () => {
+  it('blurDataURL이 없는 이미지에만 블러를 생성해 저장한다', async () => {
+    const imgA = makeImage({ id: 'a' }); // 블러 없음 → 생성 대상
+    const imgB = makeImage({ id: 'b', blurDataURL: 'data:existing' }); // 이미 있음 → 건너뜀
+    mockGetWorks.mockResolvedValue([makeWork('w1', [imgA, imgB])]);
+    mockGen.mockResolvedValue('data:newblur');
+
+    const result = await runHook();
+
+    // 갱신 대상 이미지에 대해서만 생성 호출
+    expect(mockGen).toHaveBeenCalledTimes(1);
+    expect(mockGen).toHaveBeenCalledWith(imgA.thumbnailUrl);
+
+    // updateWork는 병합된 images로 1회 호출
+    expect(mockUpdateWork).toHaveBeenCalledTimes(1);
+    const [, updates] = mockUpdateWork.mock.calls[0];
+    expect(updates.images?.[0]).toMatchObject({ id: 'a', blurDataURL: 'data:newblur' });
+    expect(updates.images?.[1]).toMatchObject({ id: 'b', blurDataURL: 'data:existing' });
+
+    expect(result.current.progress.imagesUpdated).toBe(1);
+    expect(result.current.progress.worksUpdated).toBe(1);
+    expect(result.current.progress.imagesFailed).toBe(0);
+    expect(result.current.isDone).toBe(true);
+  });
+
+  it('모든 이미지에 이미 블러가 있으면 저장하지 않는다(멱등)', async () => {
+    mockGetWorks.mockResolvedValue([
+      makeWork('w1', [makeImage({ id: 'a', blurDataURL: 'data:x' })]),
+    ]);
+
+    const result = await runHook();
+
+    expect(mockGen).not.toHaveBeenCalled();
+    expect(mockUpdateWork).not.toHaveBeenCalled();
+    expect(result.current.progress.imagesUpdated).toBe(0);
+    expect(result.current.progress.processedWorks).toBe(1);
+    expect(result.current.isDone).toBe(true);
+  });
+
+  it('블러 생성 실패(빈 문자열)는 실패로 집계하고 저장하지 않는다', async () => {
+    mockGetWorks.mockResolvedValue([makeWork('w1', [makeImage({ id: 'a' })])]);
+    mockGen.mockResolvedValue(''); // CORS/로드 실패 시뮬레이션
+
+    const result = await runHook();
+
+    expect(mockUpdateWork).not.toHaveBeenCalled();
+    expect(result.current.progress.imagesFailed).toBe(1);
+    expect(result.current.progress.imagesUpdated).toBe(0);
+    expect(result.current.isDone).toBe(true);
+  });
+});

--- a/admin/src/components/BlurBackfillManager.tsx
+++ b/admin/src/components/BlurBackfillManager.tsx
@@ -1,0 +1,125 @@
+// 기존 업로드 이미지 LQIP 블러 백필 관리 컴포넌트
+import {
+  Card,
+  Button,
+  Space,
+  Typography,
+  Alert,
+  Progress,
+  Descriptions,
+  App,
+} from 'antd';
+import { PictureOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { useEffect, useRef } from 'react';
+import { useBlurBackfill } from '../domain/hooks';
+
+const { Text, Title, Paragraph } = Typography;
+
+/**
+ * 신규 업로드부터는 블러 플레이스홀더가 자동 생성되지만, 기존에 올라간 이미지에는
+ * `blurDataURL`이 없다. 이 컴포넌트로 기존 이미지에 블러를 일괄 생성(백필)한다.
+ *
+ * 주의: 브라우저 Canvas로 원격 이미지를 읽으므로 Storage 버킷에 CORS 설정이 필요하다
+ * (미설정 시 해당 이미지는 실패로 집계되고 전체는 계속 진행).
+ */
+const BlurBackfillManager = () => {
+  const { message } = App.useApp();
+  const { isRunning, isDone, progress, error, run } = useBlurBackfill();
+  const notifiedRef = useRef(false);
+
+  // 완료/오류 시 1회 알림
+  useEffect(() => {
+    if (isRunning) {
+      notifiedRef.current = false;
+      return;
+    }
+    if (notifiedRef.current) return;
+
+    if (error) {
+      notifiedRef.current = true;
+      message.error(`백필 실패: ${error}`);
+    } else if (isDone) {
+      notifiedRef.current = true;
+      if (progress.imagesUpdated === 0 && progress.imagesFailed === 0) {
+        message.info('블러를 생성할 기존 이미지가 없습니다. 모두 최신 상태입니다.');
+      } else if (progress.imagesFailed > 0) {
+        message.warning(
+          `백필 완료: ${progress.imagesUpdated}장 생성, ${progress.imagesFailed}장 실패(CORS 설정 확인 필요)`
+        );
+      } else {
+        message.success(`백필 완료: 이미지 ${progress.imagesUpdated}장에 블러 생성`);
+      }
+    }
+  }, [isRunning, isDone, error, progress.imagesUpdated, progress.imagesFailed, message]);
+
+  const percent =
+    progress.totalWorks === 0
+      ? 0
+      : Math.round((progress.processedWorks / progress.totalWorks) * 100);
+
+  const showResult = isDone || isRunning;
+
+  return (
+    <Card style={{ marginBottom: '24px' }}>
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Title level={4} style={{ margin: 0 }}>
+          <PictureOutlined style={{ marginRight: 8 }} />
+          기존 이미지 블러 백필
+        </Title>
+
+        <Paragraph type="secondary" style={{ margin: 0 }}>
+          신규 업로드 이미지는 로딩 플레이스홀더(블러)가 자동 생성됩니다. 이 작업은
+          <Text strong> 이전에 올라간 이미지</Text>에도 블러를 일괄 생성합니다. 이미 블러가 있는
+          이미지는 건너뛰며, 중간에 멈춰도 다시 실행하면 남은 것만 처리됩니다(멱등).
+        </Paragraph>
+
+        <Alert
+          type="info"
+          showIcon
+          icon={<InfoCircleOutlined />}
+          message="실행 전 확인"
+          description={
+            <Text type="secondary">
+              브라우저에서 기존 이미지를 읽어 블러를 만들기 때문에 Storage 버킷에 CORS 설정이 필요합니다.
+              설정이 없으면 해당 이미지는 “실패”로 집계되고 나머지는 계속 진행됩니다. 설정 방법은 저장소의{' '}
+              <Text code>storage.cors.json</Text> 안내를 참고하세요.
+            </Text>
+          }
+        />
+
+        <Button
+          type="primary"
+          icon={<PictureOutlined />}
+          loading={isRunning}
+          onClick={run}
+        >
+          {isRunning ? '백필 진행 중…' : '기존 이미지 블러 백필 실행'}
+        </Button>
+
+        {showResult && (
+          <>
+            <Progress
+              percent={percent}
+              status={isRunning ? 'active' : error ? 'exception' : 'success'}
+            />
+            <Descriptions size="small" column={2} bordered>
+              <Descriptions.Item label="작품 진행">
+                {progress.processedWorks} / {progress.totalWorks}
+              </Descriptions.Item>
+              <Descriptions.Item label="갱신된 작품">{progress.worksUpdated}</Descriptions.Item>
+              <Descriptions.Item label="블러 생성">{progress.imagesUpdated}장</Descriptions.Item>
+              <Descriptions.Item label="실패">{progress.imagesFailed}장</Descriptions.Item>
+              {isRunning && progress.currentTitle && (
+                <Descriptions.Item label="현재 작품" span={2}>
+                  <Text ellipsis>{progress.currentTitle}</Text>
+                </Descriptions.Item>
+              )}
+            </Descriptions>
+          </>
+        )}
+      </Space>
+    </Card>
+  );
+};
+
+export default BlurBackfillManager;

--- a/admin/src/core/types/api.ts
+++ b/admin/src/core/types/api.ts
@@ -30,6 +30,8 @@ export interface WorkImage {
   uploadedFrom?: 'desktop' | 'mobile' | 'camera';
   /** 이미지 단위 캡션 (상세 화면에서 이미지 아래 한 줄로 표시, 선택값) */
   caption?: string;
+  /** LQIP 블러 플레이스홀더 (base64 data URL, 가로 ~20px). 신규 업로드부터 채워짐 */
+  blurDataURL?: string;
 }
 
 /**

--- a/admin/src/core/utils/image.ts
+++ b/admin/src/core/utils/image.ts
@@ -246,6 +246,54 @@ const generateBlurDataURL = (img: HTMLImageElement): string => {
   }
 };
 
+/** 백필 시 원격 이미지 로드 타임아웃 (ms) */
+const BACKFILL_LOAD_TIMEOUT_MS = 15000;
+
+/**
+ * 이미 업로드된 이미지 URL로부터 LQIP 블러 data URL을 생성한다 (기존 데이터 백필용).
+ *
+ * - `crossOrigin='anonymous'`로 로드해 Canvas에서 픽셀을 읽는다.
+ *   → 대상 버킷(Firebase Storage)에 CORS 설정이 되어 있어야 한다.
+ *     미설정 시 tainted canvas가 되어 `toDataURL`이 실패하고 빈 문자열을 반환한다.
+ * - 로드 실패 / 타임아웃 / CORS 오류 / 인코딩 실패는 모두 빈 문자열 반환(graceful, throw 금지).
+ *
+ * @param url 원본(또는 썸네일) 이미지 URL
+ */
+export const generateBlurDataURLFromUrl = (
+  url: string,
+  timeoutMs: number = BACKFILL_LOAD_TIMEOUT_MS
+): Promise<string> => {
+  return new Promise((resolve) => {
+    if (!url) {
+      resolve('');
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+
+    let settled = false;
+    const finish = (value: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => finish(''), timeoutMs);
+
+    img.onload = () => {
+      try {
+        finish(generateBlurDataURL(img));
+      } catch {
+        finish('');
+      }
+    };
+    img.onerror = () => finish('');
+    img.src = url;
+  });
+};
+
 /**
  * 이미지를 한 번만 디코딩하여 dimensions + 여러 변형을 한꺼번에 생성
  */

--- a/admin/src/core/utils/image.ts
+++ b/admin/src/core/utils/image.ts
@@ -21,6 +21,11 @@ export interface ProcessImageResult {
   thumbnail: Blob;
   medium?: Blob;
   original?: Blob;
+  /**
+   * LQIP 블러 플레이스홀더 (base64 data URL, 가로 ~20px).
+   * 생성 실패 시 빈 문자열.
+   */
+  blurDataURL: string;
 }
 
 /** Default allowed image MIME types */
@@ -190,6 +195,57 @@ const canvasToBlob = (
   });
 };
 
+/** LQIP 블러 플레이스홀더 가로 기준(px) */
+const LQIP_WIDTH = 20;
+/** LQIP data URL 길이 상한 — Firestore 인라인 저장 부담 방지 (~2KB) */
+const LQIP_MAX_DATAURL_LENGTH = 2048;
+/** 상한 초과 시 재시도할 (가로, 품질) 조합 */
+const LQIP_FALLBACK_STEPS: ReadonlyArray<{ width: number; quality: number }> = [
+  { width: 16, quality: 0.4 },
+  { width: 12, quality: 0.3 },
+];
+
+/**
+ * LQIP 블러 플레이스홀더(base64 data URL)를 생성한다.
+ * - 가로 ~20px(비율 유지)로 축소 후 WebP(미지원 시 JPEG)로 인코딩.
+ * - data URL 길이가 상한을 초과하면 가로·품질을 낮춰 재시도.
+ * - 끝까지 상한을 못 맞추거나 오류가 나면 빈 문자열 반환(graceful, throw 금지).
+ */
+const generateBlurDataURL = (img: HTMLImageElement): string => {
+  const mimeType = supportsWebP() ? 'image/webp' : 'image/jpeg';
+
+  const encode = (targetWidth: number, quality: number): string => {
+    const srcWidth = img.width || targetWidth;
+    const srcHeight = img.height || targetWidth;
+    const ratio = targetWidth / srcWidth;
+    const width = Math.max(1, Math.round(srcWidth * ratio));
+    const height = Math.max(1, Math.round(srcHeight * ratio));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return '';
+    ctx.drawImage(img, 0, 0, width, height);
+    return canvas.toDataURL(mimeType, quality);
+  };
+
+  try {
+    let dataURL = encode(LQIP_WIDTH, 0.5);
+    if (dataURL.length <= LQIP_MAX_DATAURL_LENGTH) return dataURL;
+
+    for (const step of LQIP_FALLBACK_STEPS) {
+      dataURL = encode(step.width, step.quality);
+      if (dataURL.length <= LQIP_MAX_DATAURL_LENGTH) return dataURL;
+    }
+
+    // 끝까지 상한을 못 맞추면 생성 실패로 처리
+    return '';
+  } catch {
+    return '';
+  }
+};
+
 /**
  * 이미지를 한 번만 디코딩하여 dimensions + 여러 변형을 한꺼번에 생성
  */
@@ -243,8 +299,11 @@ export const processImage = (
           }
         }
 
+        // LQIP 블러 플레이스홀더 생성 (실패해도 빈 문자열로 graceful)
+        const blurDataURL = generateBlurDataURL(img);
+
         cleanup();
-        resolve({ dimensions, thumbnail, medium, original });
+        resolve({ dimensions, thumbnail, medium, original, blurDataURL });
       } catch (error) {
         cleanup();
         reject(error instanceof Error ? error : new Error('이미지 처리 중 오류 발생'));

--- a/admin/src/core/utils/imageUploadMerge.ts
+++ b/admin/src/core/utils/imageUploadMerge.ts
@@ -6,6 +6,7 @@ import type { WorkImage } from '../types';
  * - temp(pending) 이미지는 업로드 결과(real)로 교체하되,
  *   사용자가 입력한 `order`/`caption`은 temp 이미지에서 그대로 승계한다.
  *   (real에는 caption 정보가 없으므로 승계하지 않으면 신규 업로드 이미지의 캡션이 소실된다)
+ *   `blurDataURL`(LQIP)은 업로드 결과(real)에서 생성되므로 real 값을 사용한다.
  * - 업로드 실패한 temp 이미지는 목록에서 제거한다.
  * - 최종 목록은 order를 1부터 재정렬한다.
  * - 썸네일 ID가 temp였다면 실제 ID로 교체하고, 실패한 경우 첫 이미지로 대체한다.
@@ -20,7 +21,8 @@ export const mergeUploadedImages = (
     .map((img) => {
       const real = uploadedMap.get(img.id);
       if (real) {
-        // 업로드 결과(real)로 교체하되, 사용자 입력값(order/caption)은 temp 이미지에서 승계
+        // 업로드 결과(real)로 교체하되, 사용자 입력값(order/caption)은 temp 이미지에서 승계.
+        // blurDataURL은 업로드 시 생성된 real 값을 그대로 유지(real을 먼저 펼쳐 보존).
         return { ...real, order: img.order, caption: img.caption };
       }
       // 업로드 실패한 pending 이미지는 제거

--- a/admin/src/data/api/storageApi.ts
+++ b/admin/src/data/api/storageApi.ts
@@ -65,7 +65,7 @@ export const uploadImage = async (
 
   try {
     // 1회 디코딩: dimensions + thumbnail + (선택적) 압축 원본 생성
-    const { dimensions, thumbnail, original: compressedOriginal } = await processImage(file, {
+    const { dimensions, thumbnail, original: compressedOriginal, blurDataURL } = await processImage(file, {
       thumbnail: appConfig.image.thumbnail,
       original: shouldCompress ? appConfig.image.original : undefined,
     });
@@ -113,6 +113,8 @@ export const uploadImage = async (
       height: dimensions.height,
       fileSize: file.size,
       uploadedFrom: 'desktop',
+      // LQIP 블러 플레이스홀더 — 생성 성공 시에만 포함(빈 문자열은 저장하지 않음)
+      ...(blurDataURL ? { blurDataURL } : {}),
     };
   } catch (error) {
     logger.error('이미지 업로드 실패', error, { action: 'uploadImage', fileName });

--- a/admin/src/domain/hooks/index.ts
+++ b/admin/src/domain/hooks/index.ts
@@ -78,3 +78,7 @@ export {
   usePageStats,
   useRealtimeUsers,
 } from './useAnalytics';
+
+// Blur Backfill Hook (기존 이미지 LQIP 백필)
+export { useBlurBackfill } from './useBlurBackfill';
+export type { BlurBackfillProgress } from './useBlurBackfill';

--- a/admin/src/domain/hooks/useBlurBackfill.ts
+++ b/admin/src/domain/hooks/useBlurBackfill.ts
@@ -1,0 +1,143 @@
+/**
+ * 기존 업로드 이미지 LQIP 블러 백필 훅.
+ *
+ * `blurDataURL`이 없는 기존 작품 이미지들을 순회하며, 썸네일(없으면 원본) URL로부터
+ * 블러 data URL을 생성해 Firestore 문서를 갱신한다.
+ *
+ * - 멱등(idempotent): 이미 `blurDataURL`이 있는 이미지는 건너뛴다 → 재실행 시 남은 것만 처리.
+ * - graceful: 이미지별 생성 실패(CORS/로드 오류)나 작품별 저장 실패가 나도 전체를 멈추지 않고
+ *   실패로 집계 후 계속 진행한다.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { getWorks, updateWork } from '../../data/repository/worksRepository';
+import { generateBlurDataURLFromUrl } from '../../core/utils/image';
+import type { WorkImage } from '../../core/types';
+
+export interface BlurBackfillProgress {
+  /** 전체 작품 수 */
+  totalWorks: number;
+  /** 처리 완료한 작품 수 */
+  processedWorks: number;
+  /** 이미지가 갱신되어 저장된 작품 수 */
+  worksUpdated: number;
+  /** 블러가 새로 생성·저장된 이미지 수 */
+  imagesUpdated: number;
+  /** 블러 생성/저장에 실패한 이미지 수 */
+  imagesFailed: number;
+  /** 현재 처리 중인 작품 제목 */
+  currentTitle: string;
+}
+
+interface UseBlurBackfillResult {
+  isRunning: boolean;
+  isDone: boolean;
+  progress: BlurBackfillProgress;
+  error: string | null;
+  run: () => Promise<void>;
+}
+
+const INITIAL_PROGRESS: BlurBackfillProgress = {
+  totalWorks: 0,
+  processedWorks: 0,
+  worksUpdated: 0,
+  imagesUpdated: 0,
+  imagesFailed: 0,
+  currentTitle: '',
+};
+
+/** 이미지에 블러 생성이 필요한지 (blurDataURL 없고, 소스 URL이 있음) */
+const needsBlur = (img: WorkImage): boolean =>
+  !img.blurDataURL && Boolean(img.thumbnailUrl || img.url);
+
+export const useBlurBackfill = (): UseBlurBackfillResult => {
+  const [isRunning, setIsRunning] = useState(false);
+  const [isDone, setIsDone] = useState(false);
+  const [progress, setProgress] = useState<BlurBackfillProgress>(INITIAL_PROGRESS);
+  const [error, setError] = useState<string | null>(null);
+  const runningRef = useRef(false);
+
+  const run = useCallback(async () => {
+    // 중복 실행 방지
+    if (runningRef.current) return;
+    runningRef.current = true;
+
+    setIsRunning(true);
+    setIsDone(false);
+    setError(null);
+    setProgress(INITIAL_PROGRESS);
+
+    try {
+      const works = await getWorks();
+      setProgress((p) => ({ ...p, totalWorks: works.length }));
+
+      for (const work of works) {
+        setProgress((p) => ({ ...p, currentTitle: work.title }));
+
+        const images = work.images ?? [];
+
+        // 갱신할 이미지가 없으면 저장 없이 다음 작품으로
+        if (!images.some(needsBlur)) {
+          setProgress((p) => ({ ...p, processedWorks: p.processedWorks + 1 }));
+          continue;
+        }
+
+        let updatedCount = 0;
+        let failedCount = 0;
+        const nextImages: WorkImage[] = [];
+
+        for (const img of images) {
+          if (!needsBlur(img)) {
+            nextImages.push(img);
+            continue;
+          }
+          const source = img.thumbnailUrl || img.url;
+          const blur = await generateBlurDataURLFromUrl(source);
+          if (blur) {
+            nextImages.push({ ...img, blurDataURL: blur });
+            updatedCount += 1;
+          } else {
+            nextImages.push(img);
+            failedCount += 1;
+          }
+        }
+
+        if (updatedCount > 0) {
+          try {
+            await updateWork(work.id, { images: nextImages });
+            setProgress((p) => ({
+              ...p,
+              worksUpdated: p.worksUpdated + 1,
+              imagesUpdated: p.imagesUpdated + updatedCount,
+              imagesFailed: p.imagesFailed + failedCount,
+              processedWorks: p.processedWorks + 1,
+            }));
+          } catch {
+            // 저장 실패: 생성했던 것까지 실패로 집계
+            setProgress((p) => ({
+              ...p,
+              imagesFailed: p.imagesFailed + updatedCount + failedCount,
+              processedWorks: p.processedWorks + 1,
+            }));
+          }
+        } else {
+          setProgress((p) => ({
+            ...p,
+            imagesFailed: p.imagesFailed + failedCount,
+            processedWorks: p.processedWorks + 1,
+          }));
+        }
+      }
+
+      setIsDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '백필 중 오류가 발생했습니다.');
+    } finally {
+      runningRef.current = false;
+      setIsRunning(false);
+      setProgress((p) => ({ ...p, currentTitle: '' }));
+    }
+  }, []);
+
+  return { isRunning, isDone, progress, error, run };
+};

--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -32,6 +32,7 @@ import {
   settingsCacheKeys,
 } from '../data/repository';
 import BackupManager from '../components/BackupManager';
+import BlurBackfillManager from '../components/BlurBackfillManager';
 import HomeIconManager from '../components/HomeIconManager';
 import './Settings.css';
 
@@ -252,6 +253,9 @@ const Settings = () => {
         onDeleteHomeIconHover={handleDeleteHomeIconHover}
         onUpdateIconSize={handleUpdateIconSize}
       />
+
+      {/* 이미지 성능 섹션 — 기존 이미지 블러(LQIP) 백필 */}
+      <BlurBackfillManager />
 
       {/* 데이터 관리 섹션 */}
       <BackupManager />

--- a/docs/STORAGE_CORS.md
+++ b/docs/STORAGE_CORS.md
@@ -1,0 +1,32 @@
+# Storage CORS 설정 (LQIP 백필용)
+
+기존 업로드 이미지에 블러(LQIP)를 일괄 생성하는 **백필 기능**(admin → 설정 → "기존 이미지 블러 백필")은
+브라우저 Canvas로 원격 이미지를 읽는다. 이때 Firebase Storage 버킷에 **CORS 설정**이 없으면
+canvas가 tainted 되어 블러 생성이 실패한다(해당 이미지는 "실패"로 집계되고 나머지는 계속 진행).
+
+> 신규 업로드 경로는 로컬 File을 읽으므로 CORS와 무관하다. CORS는 **백필에만** 필요하다.
+
+## 적용 방법
+
+1. 버킷 이름 확인 (예: `portfolio-nhb.appspot.com` 또는 `portfolio-nhb.firebasestorage.app`).
+2. 저장소 루트의 [`storage.cors.json`](../storage.cors.json)의 `origin`을 실제 admin 도메인에 맞게 확인/수정.
+3. `gsutil`로 적용:
+
+```bash
+gsutil cors set storage.cors.json gs://<버킷이름>
+# 예: gsutil cors set storage.cors.json gs://portfolio-nhb.appspot.com
+```
+
+4. 적용 확인:
+
+```bash
+gsutil cors get gs://<버킷이름>
+```
+
+5. admin(설정 페이지)에서 백필 실행. 실패 수가 0이면 정상.
+
+## 주의
+
+- `gsutil`은 Google Cloud SDK에 포함. 미설치 시 `gcloud` 설치 후 `gcloud auth login`.
+- CORS는 백필을 1회 돌리기 위해서만 필요하므로, 백필 완료 후 origin을 좁혀도 무방하다.
+- 백필은 멱등(idempotent): 이미 블러가 있는 이미지는 건너뛰므로 안전하게 재실행할 수 있다.

--- a/front/app/works/WorkDetailPage.tsx
+++ b/front/app/works/WorkDetailPage.tsx
@@ -555,6 +555,7 @@ export default function WorkDetailPage({ workId }: WorkDetailPageProps) {
                                 priority={isFirst}
                                 sizes={DETAIL_IMAGE_SIZES}
                                 quality={DETAIL_IMAGE_QUALITY}
+                                blurDataURL={item.data.blurDataURL}
                                 style={{
                                   width: '100%',
                                   height: 'auto',

--- a/front/src/core/types/work.types.ts
+++ b/front/src/core/types/work.types.ts
@@ -13,6 +13,8 @@ export interface WorkImage {
   uploadedFrom?: 'desktop' | 'mobile' | 'camera';
   /** 이미지 단위 캡션 (상세 화면에서 이미지 아래 한 줄로 표시, 선택값) */
   caption?: string;
+  /** LQIP 블러 플레이스홀더 (base64 data URL, 가로 ~20px). 신규 업로드부터 채워짐 */
+  blurDataURL?: string;
 }
 
 // 영상 (YouTube Embed)

--- a/front/src/presentation/__tests__/ui/media/FadeInImage.test.tsx
+++ b/front/src/presentation/__tests__/ui/media/FadeInImage.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import FadeInImage from '../../../ui/media/FadeInImage';
+
+// next/image를 단순 img로 모킹하되, 전달된 placeholder/blurDataURL을 data 속성으로 노출
+vi.mock('next/image', () => ({
+  default: (props: {
+    src: string;
+    alt: string;
+    placeholder?: string;
+    blurDataURL?: string;
+    onLoad?: () => void;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={props.src}
+      alt={props.alt}
+      data-placeholder={props.placeholder ?? ''}
+      data-blur={props.blurDataURL ?? ''}
+    />
+  ),
+}));
+
+const baseProps = {
+  src: 'https://example.com/a.jpg',
+  alt: '작품 이미지',
+  width: 800,
+  height: 600,
+};
+
+describe('FadeInImage - LQIP 블러 분기', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('blurDataURL이 있으면 placeholder="blur"로 렌더한다', () => {
+    render(<FadeInImage {...baseProps} blurDataURL="data:image/webp;base64,AAAA" />);
+    const img = screen.getByRole('img', { name: '작품 이미지' });
+    expect(img.getAttribute('data-placeholder')).toBe('blur');
+    expect(img.getAttribute('data-blur')).toBe('data:image/webp;base64,AAAA');
+  });
+
+  it('blurDataURL이 있으면 일정 시간이 지나도 스켈레톤을 표시하지 않는다', () => {
+    const { container } = render(
+      <FadeInImage {...baseProps} blurDataURL="data:image/webp;base64,AAAA" />
+    );
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(container.querySelector('.skeleton-shimmer')).toBeNull();
+  });
+
+  it('blurDataURL이 없으면 placeholder를 설정하지 않고 일정 시간 후 스켈레톤을 표시한다', () => {
+    const { container } = render(<FadeInImage {...baseProps} />);
+    const img = screen.getByRole('img', { name: '작품 이미지' });
+    expect(img.getAttribute('data-placeholder')).toBe('');
+
+    expect(container.querySelector('.skeleton-shimmer')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+    expect(container.querySelector('.skeleton-shimmer')).not.toBeNull();
+  });
+});

--- a/front/src/presentation/components/work/ModalImage.tsx
+++ b/front/src/presentation/components/work/ModalImage.tsx
@@ -71,6 +71,7 @@ export default function ModalImage({
           sizes={sizes}
           priority={priority}
           quality={quality}
+          blurDataURL={image.blurDataURL}
           style={{
             width: '100%',
             height: 'auto',

--- a/front/src/presentation/ui/media/FadeInImage.tsx
+++ b/front/src/presentation/ui/media/FadeInImage.tsx
@@ -23,6 +23,13 @@ interface FadeInImageProps {
   sizes?: string;
   /** 이미지 품질 (next/image quality). 미지정 시 Next 기본값(75) */
   quality?: number;
+  /**
+   * LQIP 블러 플레이스홀더 (base64 data URL).
+   * 제공되면 next/image `placeholder="blur"`로 첫 형상을 즉시 표시하고,
+   * 커스텀 스켈레톤/페이드 게이트는 비활성화한다.
+   * 없으면 기존 동작(스켈레톤 + fade) 유지.
+   */
+  blurDataURL?: string;
   /** 추가 스타일 */
   style?: React.CSSProperties;
 }
@@ -38,15 +45,20 @@ export default function FadeInImage({
   priority = false,
   sizes,
   quality,
+  blurDataURL,
   style = {},
 }: FadeInImageProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [showSkeleton, setShowSkeleton] = useState(false);
   const aspectRatio = height / width;
 
-  // 일정 시간 후에도 로딩 중이면 스켈레톤 표시
+  // LQIP 블러가 있으면 next/image가 자체 블러로 첫 형상을 즉시 표시하므로
+  // 커스텀 스켈레톤·페이드 게이트는 사용하지 않는다.
+  const hasBlur = Boolean(blurDataURL);
+
+  // 일정 시간 후에도 로딩 중이면 스켈레톤 표시 (블러 미사용 시에만)
   useEffect(() => {
-    if (isLoaded) return;
+    if (hasBlur || isLoaded) return;
 
     const timer = setTimeout(() => {
       if (!isLoaded) {
@@ -55,7 +67,7 @@ export default function FadeInImage({
     }, SKELETON_DELAY_MS);
 
     return () => clearTimeout(timer);
-  }, [isLoaded]);
+  }, [hasBlur, isLoaded]);
 
   return (
     <div
@@ -66,8 +78,8 @@ export default function FadeInImage({
         overflow: 'hidden',
       }}
     >
-      {/* 스켈레톤 - 일정 시간 후에도 로딩 중일 때만 표시 */}
-      {!isLoaded && showSkeleton && (
+      {/* 스켈레톤 - 블러 미사용 + 일정 시간 후에도 로딩 중일 때만 표시 */}
+      {!hasBlur && !isLoaded && showSkeleton && (
         <div
           className="skeleton-shimmer"
           style={{
@@ -90,6 +102,7 @@ export default function FadeInImage({
         priority={priority}
         sizes={sizes}
         quality={quality}
+        {...(hasBlur ? { placeholder: 'blur' as const, blurDataURL } : {})}
         onLoad={() => setIsLoaded(true)}
         style={{
           position: 'absolute',
@@ -98,10 +111,11 @@ export default function FadeInImage({
           width: '100%',
           height: '100%',
           objectFit: 'cover',
-          // LCP(priority) 이미지는 페이드 게이트 없이 즉시 표시해 paint 지연을 없앤다.
+          // 블러(LQIP) 사용 시: next/image가 자체 블러로 즉시 첫 형상을 그리므로 페이드 게이트 없음.
+          // LCP(priority) 이미지도 페이드 게이트 없이 즉시 표시.
           // 그 외 이미지는 기존 fade-in 유지.
-          opacity: priority || isLoaded ? 1 : 0,
-          transition: priority ? undefined : 'opacity 0.3s ease-in-out',
+          opacity: hasBlur || priority || isLoaded ? 1 : 0,
+          transition: hasBlur || priority ? undefined : 'opacity 0.3s ease-in-out',
         }}
       />
     </div>

--- a/storage.cors.json
+++ b/storage.cors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "origin": [
+      "http://localhost:5173",
+      "https://portfolio-nhb.web.app",
+      "https://portfolio-nhb.firebaseapp.com"
+    ],
+    "method": ["GET"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## 개요
업로드 시 admin에서 가로 ~20px 초저해상도 블러 이미지를 base64 data URL로 만들어 Firestore 문서(`WorkImage.blurDataURL`)에 인라인 저장하고, front에서 next/image `placeholder="blur"`로 첫 형상을 0ms에 표시한다. **추가 네트워크 0회, Storage egress 0.**

## 변경 요약

### admin (생성·저장)
- `core/types/api.ts`: `WorkImage.blurDataURL?: string` 필드 추가(선택값, 기존 데이터 호환).
- `core/utils/image.ts`: `processImage` 결과에 `blurDataURL` 추가. Canvas로 가로 ~20px(비율 유지) 축소 후 `toDataURL('image/webp'|'image/jpeg', 0.5)`. **크기 상한(~2KB) 검증** — 초과 시 가로·품질을 낮춰 재시도, 끝까지 못 맞추거나 오류 시 빈 문자열(graceful, throw 없음).
- `data/api/storageApi.ts`: `uploadImage()`가 생성된 `blurDataURL`을 `WorkImage`에 실어 반환(빈 문자열은 미포함).
- `core/utils/imageUploadMerge.ts`: `mergeUploadedImages()`에서 업로드 결과(real)의 `blurDataURL` 보존.
- `WorkForm.tsx`: `sanitizedImages`는 `removeUndefinedValues(img)` 스프레드라 `blurDataURL` 자동 포함(undefined 안전).

### front (소비)
- `presentation/ui/media/FadeInImage.tsx`: `blurDataURL?: string` prop 추가. 있으면 `placeholder="blur"`로 즉시 블러 표시 + 커스텀 스켈레톤/페이드 게이트 비활성화. 없으면 **기존 동작(스켈레톤 + fade) 그대로**.
- `WorkDetailPage.tsx`(인라인) / `ModalImage.tsx`(모달): `<FadeInImage>`에 `blurDataURL` 전달(이중 렌더 경로 모두).

## 디자인 변화 주의
신규 업로드 이미지는 로딩 중 **열화된 블러가 노출**된다. 기존 "빈 화면 → 1.2s 후 스켈레톤" 경험과 다르다(첫 형상이 즉시 보임).

## 합격 기준
- 첫 형상 paint ≤ FCP 근처
- 추가 전송량 장당 ≤ 2KB (data URL 상한 검증)
- LCP / SpeedIndex 악화 ±5% 이내

## 기존 데이터 fallback
`blurDataURL` 없는 기존 이미지는 자동으로 기존 스켈레톤 + fade 경로로 동작(회귀 없음).

## 검증 결과
- **front**: `npm run lint`(변경 파일 0 error), `npm run test:run`(FadeInImage/ModalImage 통과), `npm run build` green.
- **admin**: `npm run lint`(0 error), `npx vitest run`(processImageBlur/imageUploadMerge/image 통과), `npm run build` green.
- 사전 존재 실패 테스트(useFloatingPosition, useKeywordState / CaptionEditor, useWorks, settingsMapper)는 본 변경과 무관하며 main에서도 동일하게 실패함을 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)