### PR TITLE
fix: main 선재 lint 에러 · test 실패 정리

### DIFF
--- a/admin/src/__tests__/data/mappers/settingsMapper.test.ts
+++ b/admin/src/__tests__/data/mappers/settingsMapper.test.ts
@@ -17,6 +17,9 @@ describe('settingsMapper', () => {
         browserDescription: '여백의 미를 살린 미니멀한 디지털 갤러리',
         footerText: '나혜빈, hyebinnaa@gmail.com, 82)10-8745-1728',
         faviconUrl: undefined,
+        homeIconUrl: undefined,
+        homeIconHoverUrl: undefined,
+        homeIconSize: 48,
       });
     });
   });
@@ -39,6 +42,9 @@ describe('settingsMapper', () => {
         browserDescription: 'Custom Description',
         footerText: 'Custom Footer',
         faviconUrl: 'http://example.com/favicon.ico',
+        homeIconUrl: undefined,
+        homeIconHoverUrl: undefined,
+        homeIconSize: 48,
         updatedAt: new Date('2024-01-15T10:30:00Z'),
       });
     });

--- a/admin/src/data/api/backupApi.ts
+++ b/admin/src/data/api/backupApi.ts
@@ -1,6 +1,6 @@
 // 데이터 백업 및 복원 API
 import { collection, getDocs } from 'firebase/firestore';
-import { db } from '../../config/firebase';
+import { db } from './client';
 import type { Work, SentenceCategory, ExhibitionCategory, SiteSettings, BackupData } from '../../core/types';
 
 /**

--- a/admin/src/data/repository/backupRepository.ts
+++ b/admin/src/data/repository/backupRepository.ts
@@ -1,7 +1,7 @@
 // 백업/복원 Repository
 import { doc, setDoc, writeBatch, Timestamp } from 'firebase/firestore';
 import DOMPurify from 'dompurify';
-import { db } from '../../config/firebase';
+import { db } from '../api/client';
 import { createBackup, validateBackupData, downloadBackupFile } from '../api/backupApi';
 import { ValidationError } from '../../core/errors';
 import type { BackupData, RestoreOptions, Work, SentenceCategory, ExhibitionCategory, SiteSettings } from '../../core/types';

--- a/front/src/domain/__tests__/hooks/useFloatingPosition.test.ts
+++ b/front/src/domain/__tests__/hooks/useFloatingPosition.test.ts
@@ -23,7 +23,7 @@ describe('useFloatingPosition', () => {
     global.window = originalWindow;
   });
 
-  it('should center-align element below position by default', () => {
+  it('should left-align element below position by default (x = position.x + offsetX)', () => {
     const { result } = renderHook(() =>
       useFloatingPosition({
         position: { x: 500, y: 300 },
@@ -31,11 +31,12 @@ describe('useFloatingPosition', () => {
       })
     );
 
-    // x should be centered: 500 - 200/2 = 400
-    // y should be below with default offset: 300 + 8 = 308
+    // x is left-aligned with offsetX (default offsetX=0): 500 + 0 = 500
+    // y is positioned ABOVE the target by default (enough space above):
+    //   300 - height(100) - offsetY(8) = 192
     expect(result.current).toEqual({
-      x: 400,
-      y: 308,
+      x: 500,
+      y: 192,
     });
   });
 
@@ -49,8 +50,8 @@ describe('useFloatingPosition', () => {
     );
 
     expect(result.current).toEqual({
-      x: 400, // Center alignment, offset.x not used for x positioning
-      y: 315, // 300 + 15
+      x: 520, // Left alignment with offsetX: 500 + 20
+      y: 185, // Positioned above: 300 - height(100) - offsetY(15)
     });
   });
 
@@ -135,8 +136,8 @@ describe('useFloatingPosition', () => {
     rerender({ position: { x: 600, y: 400 } });
 
     expect(result.current).not.toEqual(initialPosition);
-    expect(result.current.x).toBe(500); // 600 - 200/2
-    expect(result.current.y).toBe(408); // 400 + 8
+    expect(result.current.x).toBe(600); // 600 + offsetX(0) — left aligned
+    expect(result.current.y).toBe(292); // Positioned above: 400 - height(100) - offsetY(8)
   });
 
   it('should handle window resize events', async () => {

--- a/front/src/domain/__tests__/hooks/useKeywordState.test.ts
+++ b/front/src/domain/__tests__/hooks/useKeywordState.test.ts
@@ -41,7 +41,9 @@ describe('useKeywordState', () => {
     expect(result.current).toBe('hover');
   });
 
-  it('should return "disabled" when keyword has no common works with selected category', () => {
+  it('should return "clickable" even when keyword has no common works with selected category', () => {
+    // 'disabled' 상태는 내비게이션 버그(다른 카테고리 선택 후 첫 전시 카테고리가
+    // 클릭 불가가 되는 문제) 때문에 의도적으로 제거됨. 이제 항상 'clickable' 반환.
     const keyword = createMockKeyword({
       workOrders: [{ workId: 'work-1', order: 1 }],
     });
@@ -55,7 +57,7 @@ describe('useKeywordState', () => {
       })
     );
 
-    expect(result.current).toBe('disabled');
+    expect(result.current).toBe('clickable');
   });
 
   it('should return "clickable" when keyword has common works with selected category', () => {

--- a/front/src/domain/hooks/index.ts
+++ b/front/src/domain/hooks/index.ts
@@ -22,6 +22,7 @@ export * from './useScrollLock';
 export * from './useModalLinkHandler';
 export * from './useImageTracker';
 export * from './useOptimizedResize';
+export * from './useHydrated';
 export * from './useImageZoom';
 
 // Mobile hooks

--- a/front/src/domain/hooks/useHydrated.ts
+++ b/front/src/domain/hooks/useHydrated.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * 클라이언트 하이드레이션 완료 여부를 반환하는 hook
+ *
+ * SSR(서버 렌더링) 시에는 `false`, 클라이언트 하이드레이션 이후에는 `true`를 반환한다.
+ * `useEffect` 내부에서 `setState`를 호출하는 마운트 감지 패턴(react-hooks/set-state-in-effect
+ * 규칙 위반)을 대체하기 위해 `useSyncExternalStore`를 사용한다.
+ *
+ * - getSnapshot(client): 항상 `true`
+ * - getServerSnapshot(server): 항상 `false`
+ *
+ * 외부 스토어 구독은 변경 알림이 필요 없으므로 no-op 구독을 사용한다.
+ */
+const emptySubscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useHydrated(): boolean {
+  return useSyncExternalStore(emptySubscribe, getClientSnapshot, getServerSnapshot);
+}

--- a/front/src/domain/hooks/useImageTracker.ts
+++ b/front/src/domain/hooks/useImageTracker.ts
@@ -20,14 +20,20 @@ export function useImageTracker(
   const [currentImageId, setCurrentImageId] = useState<string | null>(null);
 
   // modalWork 또는 workId 변경 시 첫 번째 미디어 ID로 초기화
-  useEffect(() => {
+  // (effect에서 setState 하는 대신, 렌더 중 직전 prop을 state로 추적해 동기적으로 재설정 —
+  //  React 공식 "prop 변경 시 state 조정" 패턴: https://react.dev/reference/react/useState)
+  const [prevWork, setPrevWork] = useState<Work | undefined>(undefined);
+  const [prevWorkId, setPrevWorkId] = useState<string | undefined>(undefined);
+  if (prevWork !== modalWork || prevWorkId !== workId) {
+    setPrevWork(modalWork);
+    setPrevWorkId(workId);
     if (modalWork) {
       const mediaItems = getMediaItems(modalWork);
       if (mediaItems.length > 0) {
         setCurrentImageId(mediaItems[0].data.id);
       }
     }
-  }, [modalWork, workId]);
+  }
 
   // IntersectionObserver + scroll 이벤트로 현재 미디어 추적
   useEffect(() => {

--- a/front/src/domain/hooks/usePinchZoom.ts
+++ b/front/src/domain/hooks/usePinchZoom.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { PINCH_ZOOM } from '@/core/constants/ui.constants';
 
 export interface UsePinchZoomOptions {
@@ -59,10 +59,16 @@ export function usePinchZoom(
     lastPanPosition: { x: 0, y: 0 },
   });
 
+  // 이벤트 핸들러에서 최신 scale/position 값을 읽기 위한 ref
+  // (렌더 중 ref를 변경하면 react-hooks/refs 규칙 위반이므로 effect에서 동기화)
   const scaleRef = useRef(scale);
   const positionRef = useRef(position);
-  scaleRef.current = scale;
-  positionRef.current = position;
+  useEffect(() => {
+    scaleRef.current = scale;
+  }, [scale]);
+  useEffect(() => {
+    positionRef.current = position;
+  }, [position]);
 
   const cleanupRef = useRef<(() => void) | null>(null);
 

--- a/front/src/presentation/components/layout/ColorPaletteDebugger.tsx
+++ b/front/src/presentation/components/layout/ColorPaletteDebugger.tsx
@@ -11,45 +11,57 @@ const STORAGE_KEY = 'debug-color-palette';
  *
  * CSS 변수를 실시간으로 조절하고 로컬스토리지에 저장합니다.
  */
+/** 기본 색상 맵 생성 */
+function buildDefaultColors(): Record<string, string> {
+  const defaultColors: Record<string, string> = {};
+  COLOR_PALETTE.forEach((color) => {
+    defaultColors[color.cssVar] = color.defaultValue;
+  });
+  return defaultColors;
+}
+
+/** 로컬스토리지에서 저장된 색상을 읽고, 없거나 파싱 실패 시 기본값 반환 */
+function loadInitialColors(): Record<string, string> {
+  if (typeof window === 'undefined') {
+    return buildDefaultColors();
+  }
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      return JSON.parse(saved) as Record<string, string>;
+    } catch (e) {
+      console.error('Failed to parse saved colors', e);
+    }
+  }
+  return buildDefaultColors();
+}
+
 export function ColorPaletteDebugger() {
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState({ x: 20, y: 80 });
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
-  const [colors, setColors] = useState<Record<string, string>>({});
+  // 로컬스토리지(외부 시스템)에서 lazy 초기화 — effect 내 setState 회피
+  const [colors, setColors] = useState<Record<string, string>>(loadInitialColors);
   const [previewVar, setPreviewVar] = useState<string | null>(null);
   const [hardcodedColors, setHardcodedColors] = useState<Array<{ element: string; color: string }>>([]);
 
-  // 초기 색상 로드 (로컬스토리지 또는 기본값)
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        setColors(parsed);
-        // CSS 변수 적용
-        Object.entries(parsed).forEach(([cssVar, value]) => {
-          document.documentElement.style.setProperty(cssVar, value as string);
-        });
-      } catch (e) {
-        console.error('Failed to parse saved colors', e);
-        resetColors();
-      }
-    } else {
-      resetColors();
-    }
-  }, []);
-
   // 색상 초기화
   const resetColors = useCallback(() => {
-    const defaultColors: Record<string, string> = {};
-    COLOR_PALETTE.forEach((color) => {
-      defaultColors[color.cssVar] = color.defaultValue;
-      document.documentElement.style.setProperty(color.cssVar, color.defaultValue);
+    const defaultColors = buildDefaultColors();
+    Object.entries(defaultColors).forEach(([cssVar, value]) => {
+      document.documentElement.style.setProperty(cssVar, value);
     });
     setColors(defaultColors);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultColors));
   }, []);
+
+  // 현재 colors 상태를 CSS 변수에 동기화 (외부 시스템 = DOM 업데이트)
+  useEffect(() => {
+    Object.entries(colors).forEach(([cssVar, value]) => {
+      document.documentElement.style.setProperty(cssVar, value);
+    });
+  }, [colors]);
 
   // 색상 변경
   const handleColorChange = useCallback((cssVar: string, value: string) => {

--- a/front/src/presentation/components/layout/PortfolioLayoutSimple.tsx
+++ b/front/src/presentation/components/layout/PortfolioLayoutSimple.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, ReactNode, useEffect, CSSProperties, ReactElement } from 'react';
+import { useCallback, useMemo, ReactNode, useEffect, CSSProperties, ReactElement } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { IS_DEBUG_LAYOUT_ENABLED } from '@/core/constants';
 import StaticCategorySidebar from './StaticCategorySidebar';
@@ -10,7 +10,7 @@ import Footer from './Footer';
 import { DebugGrid } from './DebugGrid';
 import HomeIcon from './HomeIcon';
 import { useCategories, useCategorySelection } from '@/state';
-import { useFilteredWorks, useMobileDetection, useSiteSettings } from '@/domain';
+import { useFilteredWorks, useMobileDetection, useSiteSettings, useHydrated } from '@/domain';
 import { LayoutStabilityProvider } from '@/presentation/contexts/LayoutStabilityContext';
 
 interface PortfolioLayoutSimpleProps {
@@ -46,10 +46,7 @@ export default function PortfolioLayoutSimple({ children }: PortfolioLayoutSimpl
   const isMobile = useMobileDetection();
 
   // Client-side mount state (for hydration safety)
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useHydrated();
 
   // Fetch works (선택된 카테고리에 해당하는 작품 목록)
   const { works, hasData } = useFilteredWorks(

--- a/front/src/presentation/components/mobile/MobileSwipeableCategories.tsx
+++ b/front/src/presentation/components/mobile/MobileSwipeableCategories.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useMemo, useEffect, CSSProperties } from 'react';
+import { useState, useMemo, CSSProperties } from 'react';
 import { IS_DEBUG_LAYOUT_ENABLED } from '@/core/constants';
 import { useSwipeGesture } from '@/domain/hooks/useSwipeGesture';
+import { useHydrated } from '@/domain/hooks/useHydrated';
 import { MobileCategorySlider } from './MobileCategorySlider';
 import ScrollableCategoryList from '../category/ScrollableCategoryList';
 import SentenceCategory from '../category/SentenceCategory';
@@ -44,10 +45,7 @@ export const MobileSwipeableCategories: React.FC<MobileSwipeableCategoriesProps>
   const [hoveredExhibitionCategoryId, setHoveredExhibitionCategoryId] = useState<string | null>(null);
 
   // Hydration safety: mounted state prevents SSR/client mismatch
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useHydrated();
 
   // Debug mode (development only)
   const isDebugMode = IS_DEBUG_LAYOUT_ENABLED;

--- a/front/src/presentation/components/work/CaptionWithBoundary.tsx
+++ b/front/src/presentation/components/work/CaptionWithBoundary.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { IS_DEBUG_LAYOUT_ENABLED } from '@/core/constants';
+import { useHydrated } from '@/domain';
 import { useLayoutStability } from '@/presentation/contexts/LayoutStabilityContext';
 
 interface CaptionWithBoundaryProps {
@@ -38,10 +39,7 @@ export default function CaptionWithBoundary({
   const { isLayoutStable, contentPaddingTop } = useLayoutStability();
 
   // Client-side mount state (for hydration-safe debug labels)
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useHydrated();
 
   // Debug mode (development only)
   const isDebugMode = IS_DEBUG_LAYOUT_ENABLED;

--- a/front/src/presentation/components/work/MediaTimeline.tsx
+++ b/front/src/presentation/components/work/MediaTimeline.tsx
@@ -31,6 +31,8 @@ interface MediaTimelineProps {
 interface MediaBounds {
   firstTop: number;
   lastBottom: number;
+  /** Page 모드에서 containerRef의 offsetTop (상대 위치 변환용) */
+  containerOffsetTop: number;
 }
 
 export default function MediaTimeline({
@@ -78,6 +80,7 @@ export default function MediaTimeline({
           const bounds = {
             firstTop: firstElement.offsetTop,
             lastBottom: lastElement.offsetTop + lastElement.offsetHeight,
+            containerOffsetTop: 0, // modal 모드에서는 상대 변환 불필요
           };
           setMediaBounds(bounds);
 
@@ -100,10 +103,15 @@ export default function MediaTimeline({
         if (firstElement && lastElement) {
           const firstTop = getElementOffset(firstElement);
           const lastTop = getElementOffset(lastElement);
+          // containerRef의 offsetTop을 effect 내에서 계산 (렌더 중 ref 접근 회피)
+          const containerOffsetTop = containerRef?.current
+            ? getElementOffset(containerRef.current)
+            : 0;
 
           const bounds = {
             firstTop,
             lastBottom: lastTop + lastElement.offsetHeight,
+            containerOffsetTop,
           };
           setMediaBounds(bounds);
 
@@ -376,9 +384,8 @@ export default function MediaTimeline({
     // Page 렌더링 - 미디어 범위만 그리기
     const timelineHeight = mediaBounds.lastBottom - mediaBounds.firstTop;
 
-    // containerRef의 offsetTop을 빼서 상대 위치로 변환
-    const containerOffsetTop = containerRef?.current ? getElementOffset(containerRef.current) : 0;
-    const relativeTop = mediaBounds.firstTop - containerOffsetTop;
+    // containerRef의 offsetTop을 빼서 상대 위치로 변환 (effect에서 미리 계산된 값 사용)
+    const relativeTop = mediaBounds.firstTop - mediaBounds.containerOffsetTop;
 
     // 전체 페이지 스크롤 비율 계산
     const documentHeight = typeof document !== 'undefined'


### PR DESCRIPTION
## 개요

main 브랜치에 이미 존재하던 lint 에러와 test 실패를 정리합니다. 신규 기능이 아닌 **기존 결함 수리**입니다. 모든 항목은 근본 원인을 진단해 (A) 진짜 결함으로 분류하여 규칙 비활성화/테스트 약화 없이 수정했습니다. (B)로 남긴 항목은 없습니다.

## front lint (9 errors → 0 errors)

eslint-plugin-react-hooks v7(Next 16)가 error로 승격한 React Compiler 규칙 위반. `eslint-disable` 없이 코드를 규칙에 맞게 수정.

| 파일 | 규칙 | 수정 |
|------|------|------|
| `CaptionWithBoundary.tsx`, `PortfolioLayoutSimple.tsx`, `MobileSwipeableCategories.tsx` | `set-state-in-effect` | 하이드레이션 마운트 감지(`setMounted(true)` in effect)를 `useSyncExternalStore` 기반 신규 `useHydrated` 훅으로 대체 |
| `ColorPaletteDebugger.tsx` | `set-state-in-effect` (+ 기존 use-before-declare) | `localStorage` lazy 초기화 + colors→DOM 동기화 effect로 재구성 |
| `MediaTimeline.tsx` | `refs` (렌더 중 ref 접근) | `containerOffsetTop`을 effect에서 계산해 `mediaBounds` state에 저장, 렌더는 state만 사용 |
| `usePinchZoom.ts` | `refs` (렌더 중 ref 쓰기) | `scaleRef`/`positionRef` 동기화를 effect로 이동 |
| `useImageTracker.ts` | `set-state-in-effect` | prop 변경 시 초기화 로직을 React 공식 "렌더 중 prop 변경 감지" 패턴으로 변경 |

남은 21건은 모두 baseline에도 있던 **warning**(unused-vars, exhaustive-deps)으로 error가 아니며, 상당수가 `WorkModal*`/`MediaTimeline` 등 다른 PR과 겹치는 파일이라 충돌 위험을 피하기 위해 손대지 않았습니다.

## front test:run (4 실패 → 0)

스테일 테스트가 소스의 **의도된 동작 변경**을 따라가지 못한 케이스. 소스가 올바르므로 테스트를 갱신.

- **useFloatingPosition** (3건): 커밋 `a5b90ba`에서 x 정렬이 center-align → left-align(`+offsetX`)으로 의도적으로 변경됨(프로덕션 `FloatingWorkWindow`가 `offset.x: -200`에 의존). 또한 기본 세로 배치는 "위쪽". 테스트 기대값을 실제/의도된 동작에 맞게 수정.
- **useKeywordState** (1건): `'disabled'` 상태는 내비게이션 버그로 소스에서 의도적으로 제거됨(주석으로 명시). 이제 항상 `'clickable'`. 테스트를 `'clickable'`로 갱신.

## admin vitest (2 파일 실패 → 0)

- **settingsMapper** (2건): `SiteSettings`에 `homeIconUrl`/`homeIconHoverUrl`/`homeIconSize` 필드가 추가됐는데 `toEqual` 기대값이 누락. 기대값에 신규 필드 추가.
- **CaptionEditor / useWorks** (2 파일): 모듈 로드 시 `FirebaseError: auth/invalid-api-key`로 suite 자체가 실패. **근본 원인**: `backupApi.ts`/`backupRepository.ts`만 레거시 `config/firebase`(테스트에서 모킹 안 됨)를 import해 import-time에 `getAuth` 실행. 다른 모든 API 모듈과 동일하게 정규 클라이언트 `data/api/client`(테스트 setup에서 모킹됨)를 import하도록 수정 — 테스트 통과 + 중복 Firebase 초기화/Emulator 미인지 경로 제거.

> `config/firebase.ts`는 이제 어디서도 import되지 않는 dead code이지만 삭제는 스코프 최소화를 위해 보류했습니다.

## 검증 결과

| | lint | test | build |
|--|------|------|-------|
| front | 0 errors (21 warnings) | 216 passed | ✅ green |
| admin | 0 errors (2 warnings) | 219 passed | ✅ green |

## 충돌 주의

진행 중인 다른 PR(perf/data-prefetch)이 `WorkModal.tsx`/`WorkModalMobile.tsx`를 건드립니다. 본 PR은 해당 파일을 직접 수정하지 않았으나(같은 디렉터리의 `MediaTimeline.tsx`/`CaptionWithBoundary.tsx`만 수정), 머지 순서에 따라 인접 변경으로 충돌 가능성이 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)