### PR TITLE
perf(category): 카테고리 SSR 조회 REST+캐시 전환 (TTFB 단축)

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import { queryKeys, CategoryRepository } from '@/src/data';
+import { queryKeys } from '@/src/data';
+import {
+  getSentenceCategoriesForSSR,
+  getExhibitionCategoriesForSSR,
+} from '@/data/api/categoriesServerApi';
 import { ErrorBoundary, PortfolioLayoutSimple, DebugGrid, ColorPaletteDebugger } from '@/presentation';
 import ImageZoomProvider from '@/presentation/components/layout/ImageZoomProvider';
 import { AnalyticsProvider } from '@/presentation/components/analytics/AnalyticsProvider';
@@ -35,11 +39,12 @@ async function prefetchGlobalData() {
   const prefetch = Promise.all([
     queryClient.prefetchQuery({
       queryKey: queryKeys.categories.sentence.all(),
-      queryFn: () => CategoryRepository.getSentenceCategories(),
+      // REST(캐시) 우선, 실패 시 클라이언트 SDK 폴백 — 서버 WebChannel 핸드셰이크 제거로 TTFB 단축
+      queryFn: () => getSentenceCategoriesForSSR(),
     }),
     queryClient.prefetchQuery({
       queryKey: queryKeys.categories.exhibition.all(),
-      queryFn: () => CategoryRepository.getExhibitionCategories(),
+      queryFn: () => getExhibitionCategoriesForSSR(),
     }),
   ]);
   await Promise.race([

--- a/front/src/data/__tests__/api/firestoreRest.test.ts
+++ b/front/src/data/__tests__/api/firestoreRest.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  unwrapValue,
+  unwrapFields,
+  getDocId,
+  type FirestoreRestValue,
+} from '@/data/api/firestoreRest';
+
+describe('firestoreRest.unwrapValue', () => {
+  it('기본 스칼라 타입을 언랩한다', () => {
+    expect(unwrapValue({ stringValue: 'hello' })).toBe('hello');
+    expect(unwrapValue({ stringValue: '' })).toBe('');
+    expect(unwrapValue({ integerValue: '42' })).toBe(42);
+    expect(unwrapValue({ doubleValue: 1.5 })).toBe(1.5);
+    expect(unwrapValue({ booleanValue: true })).toBe(true);
+    expect(unwrapValue({ booleanValue: false })).toBe(false);
+    expect(unwrapValue({ nullValue: null })).toBeNull();
+  });
+
+  it('timestamp/reference는 문자열 그대로 통과시킨다', () => {
+    expect(unwrapValue({ timestampValue: '2026-01-01T00:00:00Z' })).toBe(
+      '2026-01-01T00:00:00Z'
+    );
+    expect(unwrapValue({ referenceValue: 'projects/p/.../docs/x' })).toBe(
+      'projects/p/.../docs/x'
+    );
+  });
+
+  it('배열을 재귀적으로 언랩한다', () => {
+    const value: FirestoreRestValue = {
+      arrayValue: {
+        values: [{ stringValue: 'a' }, { integerValue: '2' }],
+      },
+    };
+    expect(unwrapValue(value)).toEqual(['a', 2]);
+  });
+
+  it('중첩 맵을 재귀적으로 언랩한다', () => {
+    const value: FirestoreRestValue = {
+      mapValue: {
+        fields: {
+          venue: { stringValue: 'Gallery' },
+          year: { integerValue: '2024' },
+        },
+      },
+    };
+    expect(unwrapValue(value)).toEqual({ venue: 'Gallery', year: 2024 });
+  });
+});
+
+describe('firestoreRest.unwrapFields', () => {
+  it('문서 fields 전체를 평범한 객체로 변환한다 (배열·맵 포함)', () => {
+    const result = unwrapFields({
+      sentence: { stringValue: '문장' },
+      displayOrder: { integerValue: '3' },
+      isActive: { booleanValue: true },
+      keywords: {
+        arrayValue: {
+          values: [
+            {
+              mapValue: {
+                fields: { id: { stringValue: 'k1' }, label: { stringValue: '키워드' } },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      sentence: '문장',
+      displayOrder: 3,
+      isActive: true,
+      keywords: [{ id: 'k1', label: '키워드' }],
+    });
+  });
+});
+
+describe('firestoreRest.getDocId', () => {
+  it('resource name에서 마지막 세그먼트(문서 ID)를 추출한다', () => {
+    expect(
+      getDocId('projects/p/databases/(default)/documents/sentenceCategories/abc123')
+    ).toBe('abc123');
+  });
+
+  it('빈/undefined name은 빈 문자열', () => {
+    expect(getDocId(undefined)).toBe('');
+    expect(getDocId('')).toBe('');
+  });
+});

--- a/front/src/data/api/categoriesServerApi.ts
+++ b/front/src/data/api/categoriesServerApi.ts
@@ -1,0 +1,122 @@
+/**
+ * 카테고리 서버 사이드 조회 (SSR 전용).
+ *
+ * 레이아웃 SSR 프리페치에서 카테고리를 읽을 때, 브라우저용 Firebase SDK(WebChannel/롱폴링)는
+ * 서버(Node/서버리스)에서 매 요청 연결 핸드셰이크가 느리고 연결 재사용이 안 된다.
+ * 이 모듈은 대신 **Firestore REST API(stateless HTTP)** 로 읽고 결과를 짧은 TTL로 캐시한다.
+ *
+ * - REST 실패(환경변수 부재 / 비-200 / 타임아웃 / 에뮬레이터)는 graceful: null을 반환하고
+ *   호출부가 기존 클라이언트 SDK 경로로 폴백한다(동작 보존).
+ * - 결과는 도메인 매퍼로 변환해 클라이언트 훅과 동일한 형태 → 하이드레이션 캐시 히트 유지.
+ *
+ * ⚠️ 이 모듈은 서버(레이아웃)에서만 import한다(REST 호출·unstable_cache는 서버 전용).
+ */
+
+import { unstable_cache } from 'next/cache';
+import { FIREBASE_COLLECTIONS } from '@/core/constants';
+import {
+  mapFirestoreToSentenceCategory,
+  mapFirestoreToExhibitionCategory,
+  filterActiveCategories,
+  sortByDisplayOrder,
+} from '@/data/mappers/categoryMapper';
+import { CategoryRepository } from '@/data/repository/CategoryRepository';
+import {
+  unwrapFields,
+  getDocId,
+  type FirestoreRestListResponse,
+} from '@/data/api/firestoreRest';
+import type { SentenceCategory, ExhibitionCategory } from '@/core/types';
+
+/** 카테고리는 거의 변하지 않으므로 짧은 TTL로 캐시(매 요청 Firestore 왕복 제거) */
+const CATEGORY_REVALIDATE_SECONDS = 60;
+/** REST 응답 상한 — 초과 시 폴백 */
+const REST_TIMEOUT_MS = 1500;
+
+/**
+ * Firestore REST(list documents)로 컬렉션 문서를 읽어 {id, data}로 언랩한다.
+ * 실패 시 null(폴백 신호). throw하지 않는다.
+ */
+const fetchCollectionViaRest = async (
+  collectionId: string
+): Promise<Array<{ id: string; data: Record<string, unknown> }> | null> => {
+  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+
+  // 환경변수 부재 또는 에뮬레이터 모드면 REST를 쓰지 않고 폴백
+  if (!projectId || !apiKey) return null;
+  if (process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 'true') return null;
+
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}` +
+    `/databases/(default)/documents/${collectionId}?key=${apiKey}&pageSize=300`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    const json = (await res.json()) as FirestoreRestListResponse;
+    const documents = json.documents ?? [];
+    return documents.map((doc) => ({
+      id: getDocId(doc.name),
+      data: unwrapFields(doc.fields ?? {}),
+    }));
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// --- Sentence categories ---------------------------------------------------
+
+const loadSentenceCategoriesViaRest = async (): Promise<SentenceCategory[]> => {
+  const docs = await fetchCollectionViaRest(FIREBASE_COLLECTIONS.SENTENCE_CATEGORIES);
+  if (!docs) throw new Error('sentence categories REST 조회 실패');
+  const mapped = docs.map((d) => mapFirestoreToSentenceCategory(d.id, d.data));
+  return sortByDisplayOrder(filterActiveCategories(mapped));
+};
+
+const getSentenceCategoriesCached = unstable_cache(
+  loadSentenceCategoriesViaRest,
+  ['ssr-sentence-categories'],
+  { revalidate: CATEGORY_REVALIDATE_SECONDS, tags: ['categories'] }
+);
+
+/**
+ * SSR 프리페치용: REST(캐시) 우선, 실패 시 기존 클라이언트 SDK 경로로 폴백.
+ */
+export const getSentenceCategoriesForSSR = async (): Promise<SentenceCategory[]> => {
+  try {
+    return await getSentenceCategoriesCached();
+  } catch {
+    return CategoryRepository.getSentenceCategories();
+  }
+};
+
+// --- Exhibition categories -------------------------------------------------
+
+const loadExhibitionCategoriesViaRest = async (): Promise<ExhibitionCategory[]> => {
+  const docs = await fetchCollectionViaRest(FIREBASE_COLLECTIONS.EXHIBITION_CATEGORIES);
+  if (!docs) throw new Error('exhibition categories REST 조회 실패');
+  const mapped = docs.map((d) => mapFirestoreToExhibitionCategory(d.id, d.data));
+  return sortByDisplayOrder(filterActiveCategories(mapped));
+};
+
+const getExhibitionCategoriesCached = unstable_cache(
+  loadExhibitionCategoriesViaRest,
+  ['ssr-exhibition-categories'],
+  { revalidate: CATEGORY_REVALIDATE_SECONDS, tags: ['categories'] }
+);
+
+/**
+ * SSR 프리페치용: REST(캐시) 우선, 실패 시 기존 클라이언트 SDK 경로로 폴백.
+ */
+export const getExhibitionCategoriesForSSR = async (): Promise<ExhibitionCategory[]> => {
+  try {
+    return await getExhibitionCategoriesCached();
+  } catch {
+    return CategoryRepository.getExhibitionCategories();
+  }
+};

--- a/front/src/data/api/firestoreRest.ts
+++ b/front/src/data/api/firestoreRest.ts
@@ -1,0 +1,64 @@
+/**
+ * Firestore REST API 응답 파싱 유틸 (순수 함수, Next/Firebase 비의존).
+ *
+ * REST 문서의 typed-value(`stringValue`/`integerValue`/`mapValue`/`arrayValue` ...)를
+ * 클라이언트 SDK의 `doc.data()`와 동일한 평범한 JS 객체로 언랩한다. 이렇게 하면
+ * 기존 도메인 매퍼(`mapFirestoreToSentenceCategory` 등)를 그대로 재사용할 수 있다.
+ */
+
+export interface FirestoreRestValue {
+  nullValue?: null;
+  booleanValue?: boolean;
+  integerValue?: string;
+  doubleValue?: number;
+  timestampValue?: string;
+  stringValue?: string;
+  referenceValue?: string;
+  arrayValue?: { values?: FirestoreRestValue[] };
+  mapValue?: { fields?: Record<string, FirestoreRestValue> };
+}
+
+export interface FirestoreRestDocument {
+  name?: string;
+  fields?: Record<string, FirestoreRestValue>;
+}
+
+export interface FirestoreRestListResponse {
+  documents?: FirestoreRestDocument[];
+}
+
+/** 단일 typed-value를 평범한 JS 값으로 언랩(맵/배열은 재귀) */
+export const unwrapValue = (value: FirestoreRestValue): unknown => {
+  if ('nullValue' in value) return null;
+  if (value.booleanValue !== undefined) return value.booleanValue;
+  if (value.integerValue !== undefined) return Number(value.integerValue);
+  if (value.doubleValue !== undefined) return value.doubleValue;
+  if (value.timestampValue !== undefined) return value.timestampValue;
+  if (value.stringValue !== undefined) return value.stringValue;
+  if (value.referenceValue !== undefined) return value.referenceValue;
+  if (value.arrayValue !== undefined) {
+    return (value.arrayValue.values ?? []).map(unwrapValue);
+  }
+  if (value.mapValue !== undefined) {
+    return unwrapFields(value.mapValue.fields ?? {});
+  }
+  return undefined;
+};
+
+/** REST 문서의 `fields`를 평범한 객체로 언랩 */
+export const unwrapFields = (
+  fields: Record<string, FirestoreRestValue>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(fields)) {
+    result[key] = unwrapValue(fields[key]);
+  }
+  return result;
+};
+
+/** 문서 resource name(`projects/.../documents/col/{id}`)에서 문서 ID 추출 */
+export const getDocId = (name: string | undefined): string => {
+  if (!name) return '';
+  const segments = name.split('/');
+  return segments[segments.length - 1] ?? '';
+};


### PR DESCRIPTION
## 증상
카테고리(첫 화면 사이드바) 로딩부터 네트워크 지연이 보고됨.

## 원인
`app/layout.tsx`가 `await prefetchGlobalData()`로 **HTML 첫 바이트를 카테고리 읽기에 묶어둠**. 그 읽기가 **브라우저용 Firebase SDK(WebChannel/롱폴링)** 로 서버(Node/서버리스)에서 수행돼, 매 요청 연결 핸드셰이크가 느리고 연결 재사용이 안 됨 → **TTFB에 그대로 반영**. `force-dynamic`이라 매 요청 재실행. 2초 타임아웃 초과 시 dehydrate가 비어 클라이언트가 다시 fetch → 카테고리가 뒤늦게 노출.

## 변경 (front)
- **`src/data/api/categoriesServerApi.ts`** (신규) — Firestore **REST(list documents)** 로 조회 + `unstable_cache(revalidate 60s, tag: categories)`. REST 실패(env 부재/비-200/타임아웃/에뮬레이터)는 graceful: 기존 클라이언트 SDK 경로로 폴백.
- **`src/data/api/firestoreRest.ts`** (신규) — REST typed-value(`stringValue`/`integerValue`/`mapValue`/`arrayValue`…)를 평범한 객체로 언랩하는 순수 유틸 → 기존 도메인 매퍼 재사용(하이드레이션 캐시 히트 유지).
- **`app/layout.tsx`** — SSR 프리페치 queryFn을 REST 경로로 교체. queryKey/dehydrate/HydrationBoundary 구조 그대로.
- 테스트: `firestoreRest` 언랩 로직 7건.

## 효과 / 합격 기준
- 디자인·동작 변화 없음(SSR·하이드레이션·캐시 히트 구조 동일). 비용 0.
- **측정 가능 기준**: 카테고리 SSR 읽기 시간 ≥70% 단축, **TTFB 단축**(`measure-lcp.sh`의 `LCP_TTFB_median`), 2초 타임아웃 폴백 발생률 0.
- 캐시로 대부분 요청에서 Firestore 왕복 자체가 사라짐(카테고리만, works 신선도 무관).

## 검증
- build green(`/`는 Dynamic 유지, TypeScript 통과), 신규/변경 파일 lint 0건.
- 전체 테스트 223 중 신규 7건 포함 219 통과. 잔여 실패 4건(useFloatingPosition·useKeywordState)은 **main 선재**(PR #62에서 수정), 본 변경 신규 회귀 0.

## 참고
- PR #58(이미지 SSR preload)도 Firestore REST를 쓰지만, 본 PR은 독립적으로 동작하도록 자체 REST 유틸(`firestoreRest.ts`)을 둠. 두 PR 머지 시 REST 파싱 유틸을 공용 모듈로 통합하면 중복 제거 가능.
- 실제 TTFB 단축 수치는 배포(또는 env 있는) 환경에서 `measure-lcp.sh`로 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)