### PR TITLE
feat: 사이트 소개 글(메타 설명)을 admin에서 편집 가능하게

### DIFF
--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -58,6 +58,7 @@ const Settings = () => {
         const settings = await getSiteSettings();
         siteForm.setFieldsValue({
           footerText: settings.footerText,
+          browserDescription: settings.browserDescription,
         });
         setSiteSettings({
           footerText: settings.footerText,
@@ -94,11 +95,12 @@ const Settings = () => {
 
       await updateSiteSettings({
         footerText: values.footerText,
+        browserDescription: values.browserDescription,
       });
 
       notification.success({
         message: '저장 완료',
-        description: '푸터 텍스트가 성공적으로 저장되었습니다.',
+        description: '사이트 설정이 성공적으로 저장되었습니다.',
         placement: 'topRight',
       });
     } catch (error) {
@@ -217,8 +219,23 @@ const Settings = () => {
           layout="vertical"
           initialValues={{
             footerText: '나혜빈, hyebinnaa@gmail.com, 82)10-8745-1728',
+            browserDescription: '여백의 미를 살린 미니멀한 디지털 갤러리',
           }}
         >
+          <Form.Item
+            name="browserDescription"
+            label="사이트 소개 글 (검색 노출)"
+            rules={[{ required: true, message: '사이트 소개 글을 입력하세요' }]}
+            extra="구글 등 검색 결과에 노출되는 사이트 소개 글입니다. (메타 설명, 권장 70~160자)"
+          >
+            <Input.TextArea
+              rows={3}
+              maxLength={200}
+              showCount
+              placeholder="여백의 미를 살린 미니멀한 디지털 갤러리"
+            />
+          </Form.Item>
+
           <Form.Item
             name="footerText"
             label="푸터 텍스트"

--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import {
   message,
   notification,
   Spin,
+  Alert,
 } from 'antd';
 import {
   UserOutlined,
@@ -235,6 +236,29 @@ const Settings = () => {
               placeholder="여백의 미를 살린 미니멀한 디지털 갤러리"
             />
           </Form.Item>
+
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginBottom: '24px' }}
+            message="구글 검색 결과에는 바로 반영되지 않습니다"
+            description={
+              <div style={{ lineHeight: 1.7 }}>
+                저장하면 <b>사이트 자체</b>에는 즉시 새 소개 글이 적용됩니다. 다만{' '}
+                <b>구글 검색 결과 화면</b>에 보이는 글은, 구글이 사이트를 다시 방문해
+                재색인한 뒤에야 바뀌며 보통 <b>며칠~몇 주</b>가 걸립니다. (검색엔진 구조상
+                즉시 반영은 불가능합니다.)
+                <br />
+                <br />
+                · 더 빨리 반영하려면 <b>Google Search Console</b>의 "URL 검사 → 색인 생성
+                요청"을 이용하세요.
+                <br />
+                · 구글은 이 소개 글을 항상 그대로 쓰지 않고, 검색어에 따라 본문에서 더
+                적절한 문장을 골라 스니펫을 자동 생성하기도 합니다. (소개 글은 강한
+                힌트이지 강제값이 아닙니다.)
+              </div>
+            }
+          />
 
           <Form.Item
             name="footerText"

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import { queryKeys, CategoryRepository } from '@/src/data';
+import { queryKeys, CategoryRepository, fetchSiteSettings } from '@/src/data';
 import { ErrorBoundary, PortfolioLayoutSimple, DebugGrid, ColorPaletteDebugger } from '@/presentation';
 import ImageZoomProvider from '@/presentation/components/layout/ImageZoomProvider';
 import { AnalyticsProvider } from '@/presentation/components/analytics/AnalyticsProvider';
@@ -72,14 +72,21 @@ export const viewport = {
   viewportFit: 'cover',
 };
 
-// 기본 메타데이터 (하드코딩)
-export const metadata: Metadata = {
-  title: "hyebinna",
-  description: "여백의 미를 살린 미니멀한 디지털 갤러리",
-  icons: {
-    icon: '/favicon.ico',
-  },
-};
+// 메타데이터를 서버에서 동적으로 생성한다.
+// 검색 엔진은 SSR된 HTML <head>의 description을 읽으므로, admin에서 수정한 소개 글
+// (browserDescription)이 검색 결과 스니펫에 반영되려면 여기(서버)에서 출력해야 한다.
+// force-dynamic이라 매 요청 최신값을 읽고, 조회 실패 시 기본값으로 폴백한다(graceful).
+// (title/favicon은 변경 범위 밖이라 기존 하드코딩 유지)
+export async function generateMetadata(): Promise<Metadata> {
+  const settings = await fetchSiteSettings();
+  return {
+    title: "hyebinna",
+    description: settings.browserDescription,
+    icons: {
+      icon: '/favicon.ico',
+    },
+  };
+}
 
 export default async function RootLayout({
   children,


### PR DESCRIPTION
## 개요

구글 검색 결과 스니펫에 노출되는 **사이트 소개 글**(메타 설명, `browserDescription`)을 admin에서 수정할 수 있게 하고, 그 값이 검색 엔진에 실제로 반영되도록 front를 **서버 메타데이터**로 연결합니다.

## 배경

- 기존 구글 스니펫 "여백의 미를 살린 미니멀한 디지털 갤러리"는 `front/app/layout.tsx`의 **정적** `metadata.description`에서 SSR되어, 코드 수정 없이는 바꿀 수 없었습니다.
- `browserDescription` 필드는 타입/Firestore/매퍼에 이미 존재했지만 **admin Settings UI는 `footerText`만 편집**했습니다.
- `DynamicMetadata`(클라이언트 `useEffect`) 방식은 크롤러가 읽는 **서버 HTML에 반영되지 않아** SEO에 무효였습니다 → 서버 렌더 경로로 전환.

## 변경 내용

### admin (`src/pages/Settings.tsx`)
- "사이트 설정" 카드에 **"사이트 소개 글 (검색 노출)"** `TextArea` 필드 추가 (글자수 카운터, 최대 200자)
- 폼 로드/저장에 `browserDescription` 포함 (`updateSiteSettings`·매퍼·타입은 이미 지원)

### front (`app/layout.tsx`)
- 정적 `metadata` export → **`generateMetadata()`** 로 교체
- 서버에서 `fetchSiteSettings()`로 `browserDescription`을 읽어 SSR `<head>`의 `description`에 출력
- `dynamic = 'force-dynamic'`이라 매 요청 최신값 반영, 조회 실패 시 기본값 폴백(graceful)
- `title`/`favicon`은 변경 범위(소개 글만) 밖이라 기존 하드코딩 유지

## 검증

에뮬레이터에서 end-to-end 확인 완료:

| 단계 | Firestore `browserDescription` | front SSR `<meta name="description">` |
|------|-------------------------------|----------------------------------------|
| 초기 | `나혜빈의 포트폴리오` | `나혜빈의 포트폴리오` ✅ |
| 변경 후 | `...디지털 갤러리 검증OK` | `...디지털 갤러리 검증OK` ✅ |

```bash
curl -s http://localhost:3000 | grep -o '<meta name="description"[^>]*>'
```

- admin `tsc` / `Settings.tsx` eslint 통과
- front `layout.tsx` lint·tsc 깨끗, settings 테스트 13개 통과

> 참고: 실제 구글 검색 스니펫 변경은 구글 **재크롤링/재색인** 시점에 달려 있습니다(수일~수주). 즉시 반영하려면 Search Console에서 색인 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)