### PR TITLE
experiment(isr): ISR + on-demand revalidation으로 셸 캐싱 (TTFB 실험)

### DIFF
--- a/front/app/api/revalidate-exp/route.ts
+++ b/front/app/api/revalidate-exp/route.ts
@@ -1,0 +1,14 @@
+/**
+ * On-demand revalidation 핸들러 (실험용).
+ * admin에서 작품/카테고리 발행 시 이런 엔드포인트를 호출하면, ISR 캐시를 즉시 무효화해
+ * "캐시로 빠름 + 변경 즉시 반영"을 동시에 달성한다(force-dynamic 없이 신선도 확보).
+ *
+ * 사용: POST /api/revalidate-exp
+ */
+import { revalidatePath } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  revalidatePath('/isr-exp/isr');
+  return NextResponse.json({ revalidated: true, at: Date.now() });
+}

--- a/front/app/isr-exp/dynamic/page.tsx
+++ b/front/app/isr-exp/dynamic/page.tsx
@@ -1,0 +1,33 @@
+/**
+ * 실험 baseline: force-dynamic (현재 앱과 동일한 렌더 전략).
+ * 매 요청 Firebase에서 카테고리를 읽고 서버에서 렌더 → 엣지 캐시 없음.
+ */
+export const dynamic = 'force-dynamic';
+
+async function countCategories(collection: string): Promise<number> {
+  const pid = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const key = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+  const t0 = Date.now();
+  const res = await fetch(
+    `https://firestore.googleapis.com/v1/projects/${pid}/databases/(default)/documents/${collection}?key=${key}&pageSize=300`,
+    { cache: 'no-store' }
+  );
+  const json = await res.json();
+  const n = (json.documents ?? []).length;
+  console.log(`[isr-exp:dynamic] read ${collection} -> ${n} docs in ${Date.now() - t0}ms`);
+  return n;
+}
+
+export default async function DynamicExpPage() {
+  const [sentence, exhibition] = await Promise.all([
+    countCategories('sentenceCategories'),
+    countCategories('exhibitionCategories'),
+  ]);
+  return (
+    <main style={{ padding: 24, fontFamily: 'monospace' }}>
+      <h1>DYNAMIC (force-dynamic)</h1>
+      <p>sentence={sentence} / exhibition={exhibition}</p>
+      <p>renderedAt={Date.now()}</p>
+    </main>
+  );
+}

--- a/front/app/isr-exp/isr/page.tsx
+++ b/front/app/isr-exp/isr/page.tsx
@@ -1,0 +1,36 @@
+/**
+ * 실험: ISR (revalidate 60s).
+ * 빌드/재검증 시점에만 Firebase를 읽어 HTML을 캐시하고, 그 사이 요청은 캐시된 HTML을
+ * 즉시 반환(서버 렌더·Firebase 읽기 없음). 프로덕션에선 이 캐시 HTML이 사용자와 가까운
+ * 엣지(서울)에서 서빙되어 미국 함수 왕복이 사라진다.
+ * 신선도는 on-demand revalidation(/api/revalidate-exp)으로 즉시 갱신.
+ */
+export const revalidate = 60;
+
+async function countCategories(collection: string): Promise<number> {
+  const pid = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const key = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+  const t0 = Date.now();
+  const res = await fetch(
+    `https://firestore.googleapis.com/v1/projects/${pid}/databases/(default)/documents/${collection}?key=${key}&pageSize=300`,
+    { next: { revalidate: 60 } }
+  );
+  const json = await res.json();
+  const n = (json.documents ?? []).length;
+  console.log(`[isr-exp:isr] read ${collection} -> ${n} docs in ${Date.now() - t0}ms`);
+  return n;
+}
+
+export default async function IsrExpPage() {
+  const [sentence, exhibition] = await Promise.all([
+    countCategories('sentenceCategories'),
+    countCategories('exhibitionCategories'),
+  ]);
+  return (
+    <main style={{ padding: 24, fontFamily: 'monospace' }}>
+      <h1>ISR (revalidate=60)</h1>
+      <p>sentence={sentence} / exhibition={exhibition}</p>
+      <p>renderedAt={Date.now()}</p>
+    </main>
+  );
+}

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -16,8 +16,9 @@ import {
 import React, { Suspense } from "react";
 import { LoadingContainer } from '@/presentation/ui';
 
-// 매 요청마다 서버에서 최신 데이터를 읽어 SSR(새 업로드 즉시 반영 보장).
-export const dynamic = 'force-dynamic';
+// [실험] 루트 force-dynamic 제거 → 자식 라우트가 ISR/정적 캐시 가능.
+// 홈 '/'는 page.tsx에 자체 force-dynamic이 있어 그대로 동적. 신선도는 on-demand
+// revalidation으로 대체(force-dynamic 없이 "캐시로 빠름 + 변경 즉시 반영").
 
 /** 서버 사전 페칭 상한(ms). 초과 시 부분 결과로 진행하고 클라이언트가 나머지를 페칭. */
 const SSR_PREFETCH_TIMEOUT_MS = 2000;


### PR DESCRIPTION
## 목적 (실험 — 바로 머지용 아님)
"카테고리·이미지 둘 다 느리다"의 공통 원인을 측정으로 규명하고, ISR + on-demand revalidation 접근의 효과를 실증.

## 측정으로 밝혀진 진짜 원인
- 프로덕션 응답 헤더 `x-vercel-id: icn1::iad1` → 요청은 **서울 엣지**, SSR은 **미국동부(iad1) 함수**에서 실행.
- `force-dynamic` + `no-store`(`x-vercel-cache: MISS`) → **엣지 캐시 없음**, 한국 사용자의 매 요청이 미국까지 왕복. **프로덕션 TTFB ~500ms**(DNS/TLS는 30ms뿐).
- Firebase 망 자체는 빠름(엣지까지 TCP ~10ms, Firestore REST ~120ms). → **"Firebase 느림"이 핵심 아님**. 공통 원인은 **루트 레이아웃 `force-dynamic`이 전 라우트를 동적으로 묶은 것**.

## 변경
- `app/layout.tsx` — 루트 `force-dynamic` 제거 → 자식 라우트가 ISR/정적 캐시 가능(빌드에서 `/`, `/isr-exp/isr`가 `○ Static`으로 분류됨).
- `app/isr-exp/dynamic` — force-dynamic baseline.
- `app/isr-exp/isr` — `revalidate=60` ISR.
- `app/api/revalidate-exp` — on-demand revalidation 핸들러.

## 측정 결과 (localhost, `next start`)
| | 요청당 Firebase 읽기 | 비고 |
|---|---|---|
| DYNAMIC | **18회 / 9요청** | 매 요청 읽기+렌더 |
| ISR | **0회** (빌드시만) | 캐시 HTML 서빙, on-demand revalidation 후에만 재읽기 |

→ ISR이 **요청당 Firebase 읽기+서버 렌더를 통째로 제거**. on-demand revalidation으로 **발행 시 즉시 갱신**(force-dynamic 없이 신선도 확보) 확인.
> localhost엔 Vercel 엣지가 없어 **지리적 TTFB 이득(서울 엣지가 캐시 HTML 서빙)은 미측정**. 이 브랜치를 Vercel Preview로 배포해 한국에서 `curl -w time_starttransfer`로 재면 실제 수치 확인 가능.

## 프로덕션 적용 시 필요 (이 PR엔 미포함)
- [ ] admin 발행(작품/카테고리/설정 저장) 액션에 **revalidateTag/Path 연동** → 신선도 보장
- [ ] 홈 `/`가 ISR/정적이 되어도 `useSearchParams`(workId/모달)·작품 목록이 정상인지 검증(Suspense 경계 포함)
- [ ] 이미지: 이미 엣지 31일 캐시 → 콜드 최적화만 영향. 별도 확인
- [ ] revalidate 주기·캐시 태그 설계
- [ ] 배포 후 한국에서 TTFB before/after 측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)